### PR TITLE
Fix issue with 2Dvars and 3Dvars argument not working

### DIFF
--- a/docs/source/instructions.rst
+++ b/docs/source/instructions.rst
@@ -21,7 +21,7 @@ the following two lines:
 
    url: https://cds.climate.copernicus.eu/api/v2
 
-   key: UID:KEY 
+   key: UID:KEY
 
 Replace UID with your user ID and KEY with your API key
 
@@ -37,12 +37,12 @@ Show information on available variables and levels.
 positional arguments:
  --name       Enter list name to print info list:
 
-              :samp:`levels` for all available pressure levels 
+              :samp:`levels` for all available pressure levels
 
-              :samp:`2dvars` for all available single level or 2D
+              :samp:`2Dvars` for all available single level or 2D
               variables
 
-              :samp:`3dvars` for all available 3D variables 
+              :samp:`3Dvars` for all available 3D variables
 
               Enter variable name (e.g. "total_precipitation")
               or pressure level (e.g. "825") to show if the
@@ -85,7 +85,7 @@ optional arguments:
                         data should be downloaded.
                         Every year will be downloaded in a separate file
                         by default. Set :samp:`--split false` to change this.
-  
+
   --endyear ENDYEAR
 
                         Last year of range for which  data should be
@@ -93,32 +93,32 @@ optional arguments:
                         :samp:`--startyear` needs to be specified.
                         Every year will be downloaded in a separate file
                         by default. Set :samp:`--split false` to change this.
-  
+
   --months MONTHS
 
                         Month(s) to download data for. Defaults to all
                         months. For every year in :samp:`--years` only these
                         months will be downloaded.
-  
+
   --days DAYS
 
                         Day(s) to download data for. Defaults to all days.
                         For every year in :samp:`--years` only these days will
                         be downloaded.
-  
+
   --hours HOURS
 
                         Time of day in hours to download data for.
                         Defaults to all hours. Defaults to all hours. For every year only
                         these hours will be downloaded.
-  
+
   --levels LEVELS
 
                         Pressure level(s) to download for three
                         dimensional data. Default is all available
                         levels. See the cds website or run :samp:`era5cli info
                         -h` for available pressure levels.
-  
+
   --outputprefix OUTPUTPREFIX
 
                         Prefix of output filename. Default prefix is
@@ -142,7 +142,7 @@ optional arguments:
 
                         Number of parallel threads to use when
                         downloading. Default is a single process.
-  
+
   --ensemble ENSEMBLE
 
                         Whether to download high resolution realisation
@@ -151,7 +151,7 @@ optional arguments:
                         resolution ensemble.
 
   --statistics STATISTICS
-                        
+
                         When downloading hourly ensemble data, set
                         :samp:`--statistics True` to download statistics
                         (ensemble mean and ensemble spread). Default is
@@ -188,14 +188,14 @@ optional arguments:
                         variables.
 
   --startyear STARTYEAR
- 
+
                         Single year or first year of range for which
                         data should be downloaded.
                         Every year will be downloaded in a separate file
                         by default. Set :samp:`--split false` to change this.
 
   --endyear ENDYEAR
- 
+
                         Last year of range for which  data should be
                         downloaded. If only a single year is needed, only
                         :samp:`--startyear` needs to be specified.
@@ -228,7 +228,7 @@ optional arguments:
                         -h` for available pressure levels.
 
   --outputprefix OUTPUTPREFIX
- 
+
                         Prefix of output filename. Default prefix is
                         "era5".
 
@@ -244,21 +244,21 @@ optional arguments:
                         for every year instead of mergin in one file. Default is True.
 
   --threads THREADS
- 
+
                         Choose from :samp:`[1,2,3,4,5,6]`.
 
                         Number of parallel threads to use when
                         downloading. Default is a single process.
 
   --ensemble ENSEMBLE
- 
+
                         Whether to download high resolution realisation
                         (HRES) or a reduced resolution ten member ensemble
                         (EDA). :samp:`--ensemble True` downloads the reduced
                         resolution ensemble.
 
   --synoptic SYNOPTIC
- 
+
                         Set :samp:`--synoptic True` to get monthly averaged
                         by hour of day or set :samp:`--synoptic False` to get
                         monthly means of daily means. Default is False.

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -232,9 +232,9 @@ def _parse_args(args):
         help=textwrap.dedent('''\
                              Enter list name to print info list: \n
                              "levels" for all available pressure levels \n
-                             "2dvars" for all available single level or 2D
+                             "2Dvars" for all available single level or 2D
                              variables \n
-                             "3dvars" for all available 3D variables \n
+                             "3Dvars" for all available 3D variables \n
                              Enter variable name (e.g. "total_precipitation")
                              or pressure level (e.g. "825") to show if the
                              variable or level is available and in which list.

--- a/era5cli/info.py
+++ b/era5cli/info.py
@@ -11,7 +11,7 @@ class Info:
     ----------
         infoname: str
             Name of information that needs to be printed. Supported are
-            'levels', '2dvars', '3dvars' and any variable or pressure level
+            'levels', '2Dvars', '3Dvars' and any variable or pressure level
             defined in era5cli.inputref
 
     Raises
@@ -26,6 +26,8 @@ class Info:
         """str: Name of information that needs to be printed."""
         self.infotype = None
         """str: Type of information that needs to be printed."""
+        self.infolist = []
+        """list: List with information to be printed."""
         try:
             self.infolist = ref.refdict[self.infoname]
             """list: List with information to be printed."""
@@ -57,7 +59,7 @@ class Info:
         """Define table header."""
         hdict = {
             'levels': 'pressure levels',
-            '2dvars': '2D variables',
-            '3dvars': '3D variables'
+            '2Dvars': '2D variables',
+            '3Dvars': '3D variables'
         }
         self.header = "Available {}:".format(hdict[self.infoname])

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,24 +1,30 @@
 """Tests for era5cli Fetch class."""
+import pytest
 
 from era5cli import info
 
 
-def test_init():
+@pytest.mark.parametrize(
+    'arg',
+    ['levels', '2Dvars', '3Dvars', 'total_precipitation', 'temperature'])
+def test_init(arg):
     """Test init function of Info class."""
-    era5info = info.Info('levels')
+    era5info = info.Info(arg)
     assert isinstance(era5info.infolist, list)
 
 
-def test_define_table_header():
+@pytest.mark.parametrize('arg', ['levels', '2Dvars', '3Dvars'])
+def test_define_table_header(arg):
     """Test _define_table_header function of Info class."""
-    era5info = info.Info('levels')
+    era5info = info.Info(arg)
     era5info._define_table_header()
     assert isinstance(era5info.header, str)
 
 
-def test_list():
+@pytest.mark.parametrize('arg', ['levels', '2Dvars', '3Dvars'])
+def test_list(arg):
     """Test list function of Info class."""
-    era5info = info.Info('levels')
+    era5info = info.Info(arg)
     era5info.list()
     assert True
 


### PR DESCRIPTION
The info command was not working correctly, because of spelling differences in 2dvars/2Dvars, 3dvars/3Dvars. This pull request fixes that.
```
$ era5cli info 2Dvars
Traceback (most recent call last):
  File "/home/bandela/conda/envs/split/bin/era5cli", line 11, in <module>
    load_entry_point('era5cli', 'console_scripts', 'era5cli')()
  File "/home/bandela/src/era5cli/era5cli/cli.py", line 306, in main
    _execute(args)
  File "/home/bandela/src/era5cli/era5cli/cli.py", line 255, in _execute
    era5info.list()
  File "/home/bandela/src/era5cli/era5cli/info.py", line 46, in list
    self._define_table_header()
  File "/home/bandela/src/era5cli/era5cli/info.py", line 63, in _define_table_header
    self.header = "Available {}:".format(hdict[self.infoname])
KeyError: '2Dvars'
```