### PR TITLE
add more useful information to netCDF history

### DIFF
--- a/era5cli/fetch.py
+++ b/era5cli/fetch.py
@@ -275,4 +275,4 @@ class Fetch:
             connection = cdsapi.Client()
             print("".join(queueing_message))  # print queueing message
             connection.retrieve(name, request, outputfile)
-            era5cli.utils._append_history(outputfile)
+            era5cli.utils._append_history(name, request, outputfile)

--- a/era5cli/utils.py
+++ b/era5cli/utils.py
@@ -4,6 +4,8 @@ import shutil
 import prettytable
 from netCDF4 import Dataset
 from pathlib import Path
+import datetime
+import textwrap
 
 import era5cli
 from era5cli.__version__ import __version__ as era5cliversion
@@ -149,7 +151,7 @@ def _print_multicolumn(header: str, info: list):
     print(table)
 
 
-def _append_history(fname):
+def _append_history(name, request, fname):
     """Append era5cli version information.
 
     Parameters
@@ -157,8 +159,10 @@ def _append_history(fname):
     fname: str
         Filename.
     """
-    appendtxt = "Downloaded using {} {}.".format(era5cli.__name__,
-                                                 era5cliversion)
+    dtime = datetime.datetime.now(tz=datetime.timezone.utc).strftime(
+        "%Y-%m-%d %H:%M:%S %Z")
+    appendtxt = "{} by {} {}: {} {}".format(dtime, era5cli.__name__,
+                                            era5cliversion, name, request)
     extension = Path(fname).suffix
     if extension == ".nc":
         _append_netcdf_history(fname, appendtxt)
@@ -177,7 +181,9 @@ def _append_netcdf_history(ncfile: str, appendtxt: str):
     # open netCDF file rw and append to history
     ncfile = Dataset(ncfile, 'r+')
     try:
-        ncfile.history = "{}\n{}".format(appendtxt, ncfile.history)
+        ncfile.history = textwrap.dedent('''\
+            {}
+            {}'''.format(appendtxt, ncfile.history))
     except AttributeError:
         ncfile.history = appendtxt
     ncfile.close()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -125,13 +125,15 @@ def test_append_history():
     """Test append_history utility function."""
     # test netCDF file with existing history
     (fd, filename) = tempfile.mkstemp(suffix=".nc")
+    name = "reanalysis-era5-single-levels"
+    request = "request"
     # create tmp netCDF file
     ncfile = Dataset(filename, 'w')
     orig_history = "Test history line."
     ncfile.history = orig_history
     ncfile.close()
     # test append history
-    era5cli.utils._append_history(filename)
+    era5cli.utils._append_history(name, request, filename)
     # load netCDF file
     ncfile = Dataset(filename, 'r')
     new_history = ncfile.history
@@ -139,7 +141,7 @@ def test_append_history():
         era5cli.__name__,
         era5cliversion)
     hist_split = new_history.split('\n')
-    assert hist_split[0] == appendtxt
+    assert hist_split[0].split()[-2:] == [name, request]
     assert hist_split[1] == orig_history
     # remove temporary file
     os.remove(filename)
@@ -148,7 +150,7 @@ def test_append_history():
     ncfile = Dataset(filename, 'w')
     ncfile.close()
     # test append history
-    era5cli.utils._append_history(filename)
+    era5cli.utils._append_history(name, request, filename)
     # load netCDF file
     ncfile = Dataset(filename, 'r')
     new_history = ncfile.history


### PR DESCRIPTION
This PR adds the date and time, as well as the request to the netCDF history.

Line breaks and escape characters is something that seems to be unremovable, also looking at other netCDF files I have around produced using other tools.