### PR TITLE
Add preliminary back extension support (closes #54)

### DIFF
--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -127,6 +127,17 @@ def _build_parser():
                              ''')
     )
 
+    common.add_argument(
+        "--preliminary-back-extension", action="store_true", default=False,
+        help=textwrap.dedent('''\
+                             Whether to download the preliminary back extension
+                             (1950-1978). Providing the
+                             "--preliminary-back-extension" argument downloads
+                             the preliminary back extension.
+
+                             ''')
+    )
+
     mnth = argparse.ArgumentParser(add_help=False)
 
     mnth.add_argument(
@@ -328,7 +339,9 @@ def _execute(args):
                             statistics=statistics,
                             pressurelevels=args.levels,
                             threads=args.threads,
-                            merge=args.merge)
+                            merge=args.merge,
+                            preliminary_back_extension=
+                            args.preliminary_back_extension)
         era5.fetch(dryrun=args.dryrun)
         return True
 

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -326,22 +326,23 @@ def _execute(args):
 
         synoptic, statistics, days, hours = _set_period_args(args)
         # try to build and send download request
-        era5 = efetch.Fetch(years,
-                            months=args.months,
-                            days=days,
-                            hours=hours,
-                            variables=args.variables,
-                            outputformat=args.format,
-                            outputprefix=args.outputprefix,
-                            period=args.command,
-                            ensemble=args.ensemble,
-                            synoptic=synoptic,
-                            statistics=statistics,
-                            pressurelevels=args.levels,
-                            threads=args.threads,
-                            merge=args.merge,
-                            preliminary_back_extension=
-                            args.preliminary_back_extension)
+        era5 = efetch.Fetch(
+            years,
+            months=args.months,
+            days=days,
+            hours=hours,
+            variables=args.variables,
+            outputformat=args.format,
+            outputprefix=args.outputprefix,
+            period=args.command,
+            ensemble=args.ensemble,
+            synoptic=synoptic,
+            statistics=statistics,
+            pressurelevels=args.levels,
+            threads=args.threads,
+            merge=args.merge,
+            preliminary_back_extension=args.preliminary_back_extension,
+        )
         era5.fetch(dryrun=args.dryrun)
         return True
 

--- a/era5cli/fetch.py
+++ b/era5cli/fetch.py
@@ -57,13 +57,15 @@ class Fetch:
             Indicating if files should be downloaded. By default
             files will be downloaded. For a dryrun the cdsapi request will
             be written to stdout.
+        preliminary_back_extension: bool
+            Whether to download the preliminary back extension (1950-1978).
     """
 
     def __init__(self, years: list, months: list, days: list,
                  hours: list, variables: list, outputformat: str,
                  outputprefix: str, period: str, ensemble: bool,
                  statistics=None, synoptic=None, pressurelevels=None,
-                 merge=False, threads=None):
+                 merge=False, threads=None, preliminary_back_extension=False):
         """Initialization of Fetch class."""
         self.months = era5cli.utils._zpad_months(months)
         """list(str): List of zero-padded strings of months
@@ -107,6 +109,7 @@ class Fetch:
         """bool: Whether to get monthly averaged by hour of day
         (synoptic=True) or monthly means of daily means
         (synoptic=False)."""
+        self.preliminary_back_extension = preliminary_back_extension
 
     def fetch(self, dryrun=False):
         """Split calls and fetch results.
@@ -252,6 +255,9 @@ class Fetch:
             # Add day list to request if applicable
             if self.days:
                 request["day"] = self.days
+
+        if self.preliminary_back_extension:
+            name += "-preliminary-back-extension"
 
         return(name, request)
 


### PR DESCRIPTION
This adds support for the preliminary back extension. It's not super sophisticated but works for me. It's marked to close #54, but it really only addresses the preliminary back extension, not the era5 land part. However, since the two are quite different in nature, I think it's probably best to add a new issue about that.

Things to check for stylistic compliance:
- order of option in adding to argument parser and `era5cli.fetch.Fetch.__init__`
- docstrings and comments in `era5cli.fetch.Fetch`

Possible modifications/amendments:
- check time range
- (semi-)automatically apply back extension where applicable (years prior to 1979)