### PR TITLE
Add preliminary back extension support

### DIFF
--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -283,12 +283,13 @@ def _run_info(args):
         era5info.vars()
         return True
 
+
 def _construct_year_list(args):
     if not args.endyear:
         endyear = args.startyear
     else:
         endyear = args.endyear
-        
+
     # check whether correct years have been entered
     for year in (args.startyear, endyear):
         if args.prelimbe:
@@ -299,10 +300,10 @@ def _construct_year_list(args):
             assert 1979 <= year <= datetime.now().year, (
                 'year should be between 1979 and present'
             )
-    
+
     assert endyear >= args.startyear, (
         'endyear should be >= startyear or None')
-    
+
     # make list of years to be downloaded
     years = list(range(args.startyear, endyear + 1))
 

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -315,7 +315,7 @@ def _set_period_args(args):
     if args.command == "monthly":
         statistics = None
         days = None
-        if not args.synoptic:
+        if args.synoptic is False:
             synoptic = None
             hours = [0]
         elif len(args.synoptic) == 0:

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -128,11 +128,11 @@ def _build_parser():
     )
 
     common.add_argument(
-        "--preliminary-back-extension", action="store_true", default=False,
+        "--prelimbe", action="store_true", default=False,
         help=textwrap.dedent('''\
                              Whether to download the preliminary back extension
                              (1950-1978). Providing the
-                             "--preliminary-back-extension" argument downloads
+                             "--prelimbe" argument downloads data from
                              the preliminary back extension.
 
                              ''')
@@ -341,7 +341,7 @@ def _execute(args):
             pressurelevels=args.levels,
             threads=args.threads,
             merge=args.merge,
-            preliminary_back_extension=args.preliminary_back_extension,
+            prelimbe=args.prelimbe,
         )
         era5.fetch(dryrun=args.dryrun)
         return True

--- a/era5cli/fetch.py
+++ b/era5cli/fetch.py
@@ -110,7 +110,7 @@ class Fetch:
         (synoptic=True) or monthly means of daily means
         (synoptic=False)."""
         self.prelimbe = prelimbe
-        """bool: Whether to select from the ERA5 preliminary back 
+        """bool: Whether to select from the ERA5 preliminary back
         extension which supports years from 1950 to 1978"""
 
     def fetch(self, dryrun=False):
@@ -200,7 +200,7 @@ class Fetch:
         elif not self.ensemble:
             producttype += "reanalysis"
 
-        if self.period == "monthly" and not self.prelimbe: 
+        if self.period == "monthly" and not self.prelimbe:
             producttype = "monthly_averaged_" + producttype
             if self.synoptic:
                 producttype += "_by_hour_of_day"
@@ -219,7 +219,7 @@ class Fetch:
                 "ensemble_mean",
                 "ensemble_spread",
             ]
-            
+
         return producttype
 
     def _build_request(self, variable, years):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,6 +46,14 @@ def test_period_args():
     period_args = cli._set_period_args(args)
     # Period_args consists of (synoptic, statistics, days, hours)
     assert period_args == (True, None, None, [4, 7])
+    
+    argv = ['monthly', '--startyear', '2008',
+            '--variables', 'total_precipitation',
+            '--synoptic', '--ensemble']
+    args = cli._parse_args(argv)
+    period_args = cli._set_period_args(args)
+    # Period_args consists of (synoptic, statistics, days, hours)
+    assert period_args == (True, None, None, range(0,24))
 
     # test whether the info option does not end up in _set_period_args
     argv = ['info', '2Dvars']

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,14 +46,14 @@ def test_period_args():
     period_args = cli._set_period_args(args)
     # Period_args consists of (synoptic, statistics, days, hours)
     assert period_args == (True, None, None, [4, 7])
-    
+
     argv = ['monthly', '--startyear', '2008',
             '--variables', 'total_precipitation',
             '--synoptic', '--ensemble']
     args = cli._parse_args(argv)
     period_args = cli._set_period_args(args)
     # Period_args consists of (synoptic, statistics, days, hours)
-    assert period_args == (True, None, None, range(0,24))
+    assert period_args == (True, None, None, range(0, 24))
 
     # test whether the info option does not end up in _set_period_args
     argv = ['info', '2Dvars']

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,6 +71,22 @@ def test_main_fetch(fetch):
     with pytest.raises(AssertionError):
         assert cli._execute(args)
 
+    # should give an AssertionError if years are out of bounds
+    argv = ['hourly', '--startyear', '1950',
+            '--variables', 'total_precipitation', '--statistics',
+            '--endyear', '2007', '--ensemble']
+    args = cli._parse_args(argv)
+    with pytest.raises(AssertionError):
+        assert cli._execute(args)
+
+    # should give an AssertionError if years are out of bounds
+    argv = ['hourly', '--startyear', '1950',
+            '--variables', 'total_precipitation', '--statistics',
+            '--endyear', '2007', '--ensemble', '--prelimbe']
+    args = cli._parse_args(argv)
+    with pytest.raises(AssertionError):
+        assert cli._execute(args)
+
     # monthly call without endyear
     argv = ['monthly', '--startyear', '2008',
             '--variables', 'total_precipitation', '--synoptic',

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -25,7 +25,8 @@ def initialize(outputformat='netcdf', merge=False, statistics=None,
                        synoptic=synoptic,
                        pressurelevels=pressurelevels,
                        merge=merge,
-                       threads=threads)
+                       threads=threads,
+                       prelimbe=prelimbe)
     return era5
 
 
@@ -44,7 +45,8 @@ def test_init():
                        synoptic=None,
                        pressurelevels=None,
                        merge=False,
-                       threads=2)
+                       threads=2,
+                       prelimbe=False)
 
     valid_months = ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10',
                     '11', '12']
@@ -262,6 +264,10 @@ def test_product_type():
     producttype = era5._product_type()
     assert producttype == 'reanalysis-synoptic-monthly-means'
 
+    era5.ensemble = True
+    producttype = era5._product_type()
+    assert producttype == 'members-synoptic-monthly-means'
+
     era5.prelimbe = False
     era5.ensemble = False
     era5.statistics = True
@@ -290,7 +296,6 @@ def test_build_request():
                     '12:00', '13:00', '14:00', '15:00', '16:00', '17:00',
                     '18:00', '19:00', '20:00', '21:00', '22:00', '23:00'],
            'format': 'netcdf'}
-    print(request['day'])
     assert request == req
 
     # monthly data
@@ -301,6 +306,28 @@ def test_build_request():
     assert name == 'reanalysis-era5-single-levels-monthly-means'
     req = {'variable': 'total_precipitation', 'year': [2008],
            'product_type': 'monthly_averaged_ensemble_members',
+           'month': ['01', '02', '03', '04', '05', '06',
+                     '07', '08', '09', '10', '11', '12'],
+           'time': ['00:00', '01:00', '02:00', '03:00', '04:00', '05:00',
+                    '06:00', '07:00', '08:00', '09:00', '10:00', '11:00',
+                    '12:00', '13:00', '14:00', '15:00', '16:00', '17:00',
+                    '18:00', '19:00', '20:00', '21:00', '22:00', '23:00'],
+           'format': 'netcdf'}
+    assert request == req
+
+    # preliminary back extension
+    era5 = initialize(period='monthly',
+                      variables=['total_precipitation'],
+                      years=[1970],
+                      prelimbe=True)
+    (name, request) = era5._build_request('total_precipitation', [1970])
+    print(request)
+    assert name == (
+        "reanalysis-era5-single-levels-monthly"
+        "-means-preliminary-back-extension"
+    )
+    req = {'variable': 'total_precipitation', 'year': [1970],
+           'product_type': 'members-monthly-means-of-daily-means',
            'month': ['01', '02', '03', '04', '05', '06',
                      '07', '08', '09', '10', '11', '12'],
            'time': ['00:00', '01:00', '02:00', '03:00', '04:00', '05:00',

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -9,7 +9,8 @@ def initialize(outputformat='netcdf', merge=False, statistics=None,
                synoptic=None, ensemble=True, pressurelevels=None,
                threads=2, period='hourly', variables=['total_precipitation'],
                years=[2008, 2009], months=list(range(1, 13)),
-               days=list(range(1, 32)), hours=list(range(0, 24))):
+               days=list(range(1, 32)), hours=list(range(0, 24)),
+               prelimbe=False):
     """Initializer of the class."""
     era5 = fetch.Fetch(years=years,
                        months=months,
@@ -71,6 +72,7 @@ def test_init():
     assert era5.pressure_levels is None
     assert not era5.merge
     assert era5.threads == 2
+    assert not era5.prelimbe
 
     # initializing hourly variable with days=None should result in ValueError
     with pytest.raises(TypeError):
@@ -247,10 +249,20 @@ def test_product_type():
     producttype = era5._product_type()
     assert producttype == 'monthly_averaged_reanalysis'
 
+    era5.prelimbe = True
+    producttype = era5._product_type()
+    assert producttype == 'reanalysis-monthly-means-of-daily-means'
+
+    era5.prelimbe = False
     era5.synoptic = True
     producttype = era5._product_type()
     assert producttype == 'monthly_averaged_reanalysis_by_hour_of_day'
 
+    era5.prelimbe = True
+    producttype = era5._product_type()
+    assert producttype == 'reanalysis-synoptic-monthly-means'
+
+    era5.prelimbe = False
     era5.ensemble = False
     era5.statistics = True
     producttype = era5._product_type()


### PR DESCRIPTION
Continues the work in PR https://github.com/eWaterCycle/era5cli/pull/56 to support the preliminary back extension of era5.
Addresses part of issue #54 
Fixes #60 