### PR TITLE
Fix gh-actions PyPI publishing automation

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,8 +1,8 @@
 name: Publish Python distributions to PyPI and TestPyPI
 
-on: 
-  release:
-    types: [published]
+on: push
+  # release:
+  #   types: [published]
 
 
 jobs:
@@ -32,17 +32,25 @@ jobs:
         --wheel
         --outdir dist/
 
-    # Publish the package to test.pypi for every tagged version
+    # test
     - name: Publish distribution to Test PyPI
-      if: startsWith(github.ref, 'refs/tags')
+      if: "!contains(github.ref, 'gh-actions') && !contains(github.ref, 'rc')"
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: http://test.pypi.org/legacy/
 
-    # Publish a tagged version on PyPI for non-release candidates
-    - name: Publish distribution to PyPI
-      if: startsWith(github.ref, 'refs/tags') && ! contains(github.ref, 'rc')
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.pypi_password }}
+    # # Publish the package to test.pypi for every tagged version
+    # - name: Publish distribution to Test PyPI
+    #   if: startsWith(github.ref, 'refs/tags')
+    #   uses: pypa/gh-action-pypi-publish@master
+    #   with:
+    #     password: ${{ secrets.test_pypi_password }}
+    #     repository_url: http://test.pypi.org/legacy/
+
+    # # Publish a tagged version on PyPI for non-release candidates
+    # - name: Publish distribution to PyPI
+    #   if: "startsWith(github.ref, 'refs/tags') && !contains(github.ref, 'rc')"
+    #   uses: pypa/gh-action-pypi-publish@master
+    #   with:
+    #     password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -34,7 +34,7 @@ jobs:
 
     # test
     - name: Publish distribution to Test PyPI
-      if: "!contains(github.ref, 'gh-actions') && !contains(github.ref, 'rc')"
+      if: "contains(github.ref, 'gh-actions') && !contains(github.ref, 'rc')"
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.test_pypi_password }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,8 +1,8 @@
 name: Publish Python distributions to PyPI and TestPyPI
 
-on: push
-  # release:
-  #   types: [published]
+on:
+  release:
+    types: [published]
 
 
 jobs:
@@ -32,25 +32,17 @@ jobs:
         --wheel
         --outdir dist/
 
-    # test
+    # Publish the package to test.pypi for every tagged version
     - name: Publish distribution to Test PyPI
-      if: "contains(github.ref, 'gh-actions') && !contains(github.ref, 'rc')"
+      if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: http://test.pypi.org/legacy/
 
-    # # Publish the package to test.pypi for every tagged version
-    # - name: Publish distribution to Test PyPI
-    #   if: startsWith(github.ref, 'refs/tags')
-    #   uses: pypa/gh-action-pypi-publish@master
-    #   with:
-    #     password: ${{ secrets.test_pypi_password }}
-    #     repository_url: http://test.pypi.org/legacy/
-
-    # # Publish a tagged version on PyPI for non-release candidates
-    # - name: Publish distribution to PyPI
-    #   if: "startsWith(github.ref, 'refs/tags') && !contains(github.ref, 'rc')"
-    #   uses: pypa/gh-action-pypi-publish@master
-    #   with:
-    #     password: ${{ secrets.pypi_password }}
+    # Publish a tagged version on PyPI for non-release candidates
+    - name: Publish distribution to PyPI
+      if: "startsWith(github.ref, 'refs/tags') && !contains(github.ref, 'rc')"
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.pypi_password }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Release Notes
 *************
 
-1.1.1rc1 (2020-12-15)
+1.1.1 (2020-12-15)
 ~~~~~~~~~~~~~~~~~~~~~
 * Patch to fix the github actions publish automation `#64 <https://github.com/eWaterCycle/era5cli/pull/64>`_
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Release Notes
 *************
 
+1.1.1rc1 (2020-12-15)
+~~~~~~~~~~~~~~~~~~~~~
+* Patch to fix the github actions publish automation `#64 <https://github.com/eWaterCycle/era5cli/pull/64>`_
+
 1.1.0 (2020-12-14)
 ~~~~~~~~~~~~~~~~~~~~~
 * The stable 1.1.0 era5cli minor release.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,9 @@
 Release Notes
 *************
 
-1.1.0rc1 (2020-12-14)
+1.1.0 (2020-12-14)
 ~~~~~~~~~~~~~~~~~~~~~
-* The 1.1.0 era5cli minor release.
+* The stable 1.1.0 era5cli minor release.
 * Add support for ERA5 preliminary back extension `#58 <https://github.com/eWaterCycle/era5cli/pull/58>`_
 * Update tests `#57 <https://github.com/eWaterCycle/era5cli/pull/57>`_
 * Add automated PyPI package building and publishing with github Actions `#62 <https://github.com/eWaterCycle/era5cli/pull/62>`_

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -54,4 +54,4 @@ license: Apache-2.0
 message: "If you use this software, please cite it using these metadata."
 repository-code: "https://github.com/ewatercycle/era5cli"
 title: era5cli
-version: 1.1.0rc1
+version: 1.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -54,4 +54,4 @@ license: Apache-2.0
 message: "If you use this software, please cite it using these metadata."
 repository-code: "https://github.com/ewatercycle/era5cli"
 title: era5cli
-version: 1.1.0
+version: 1.1.1rc1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -54,4 +54,4 @@ license: Apache-2.0
 message: "If you use this software, please cite it using these metadata."
 repository-code: "https://github.com/ewatercycle/era5cli"
 title: era5cli
-version: 1.1.1rc1
+version: 1.1.1

--- a/era5cli/__version__.py
+++ b/era5cli/__version__.py
@@ -10,4 +10,4 @@ __author__ = ('Ronald van Haren', 'Jaro Camphuijsen', 'Yifat Dzigan',
               'Niels Drost', 'Fakhereh Alidoost', 'Bouwe Andela',
               'Jerom Aerts', 'Berend Weel', 'Rolf Hut', 'Klaus Zimmermann')
 __email__ = 'ewatercycle@esciencecenter.nl'
-__version__ = '1.1.0'
+__version__ = '1.1.1rc1'

--- a/era5cli/__version__.py
+++ b/era5cli/__version__.py
@@ -10,4 +10,4 @@ __author__ = ('Ronald van Haren', 'Jaro Camphuijsen', 'Yifat Dzigan',
               'Niels Drost', 'Fakhereh Alidoost', 'Bouwe Andela',
               'Jerom Aerts', 'Berend Weel', 'Rolf Hut', 'Klaus Zimmermann')
 __email__ = 'ewatercycle@esciencecenter.nl'
-__version__ = '1.1.0rc1'
+__version__ = '1.1.0'

--- a/era5cli/__version__.py
+++ b/era5cli/__version__.py
@@ -10,4 +10,4 @@ __author__ = ('Ronald van Haren', 'Jaro Camphuijsen', 'Yifat Dzigan',
               'Niels Drost', 'Fakhereh Alidoost', 'Bouwe Andela',
               'Jerom Aerts', 'Berend Weel', 'Rolf Hut', 'Klaus Zimmermann')
 __email__ = 'ewatercycle@esciencecenter.nl'
-__version__ = '1.1.1rc1'
+__version__ = '1.1.1'


### PR DESCRIPTION
Test the gh-actions publishing workflow to automate releases on PyPI.
Update version for new patch release 1.1.1