### PR TITLE
Improve documentation about coordinate variables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ era5cli
 
 A command line interface to download ERA5 data from the `Copernicus Climate Data Store <https://climate.copernicus.eu/>`_.
 
-With era5cli you can: ​
+With era5cli you can:
 
 - download meteorological data in GRIB/NetCDF
 - list and retrieve information on available variables and pressure levels

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -166,7 +166,7 @@ def _build_parser():
         help=textwrap.dedent('''\
                             Coordinates in case extraction of a subregion is
                             requested.
-                            Specified as lat_max lon_min lat_min lon_max
+                            Specified as LAT_MAX LON_MIN LAT_MIN LON_MAX
                             (counterclockwise coordinates, starting at the top)
                             with longitude and latitude in the range
                             -180, +180 and -90, +90, respectively e.g.

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -161,16 +161,17 @@ def _build_parser():
 
     common.add_argument(
         "--area", nargs=4, type=float,
+        metavar=('LAT_MAX', 'LON_MIN', 'LAT_MIN', 'LON_MAX'),
         required=False,
         help=textwrap.dedent('''\
                             Coordinates in case extraction of a subregion is
-                            requested. Specified as
-                            ymax xmin ymin xmax with x and y in the
-                            range -180, +180 and -90, +90, respectively
-                            e.g. --area 90 -180 -90 180.
-                            Requests are rounded down to two decimals.
-                            Without specification, the whole available area
-                            will be returned.
+                            requested. Specified as lat_max lon_min lat_min lon_max
+                            (counterclockwise coordinates, starting at the top)
+                            with longitude and latitude in the range
+                            -180, +180 and -90, +90, respectively e.g.
+                            --area 90 -180 -90 180. Requests are rounded down to two
+                            decimals. Without specification, the whole available
+                            area will be returned.
 
                             ''')
     )

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -171,7 +171,7 @@ def _build_parser():
                             with longitude and latitude in the range
                             -180, +180 and -90, +90, respectively e.g.
                             --area 90 -180 -90 180. Requests are rounded down
-                            to two decimals. Without specification, the whole
+                            to two decimals. By default, the entire
                             available area will be returned.
 
                             ''')

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -165,13 +165,14 @@ def _build_parser():
         required=False,
         help=textwrap.dedent('''\
                             Coordinates in case extraction of a subregion is
-                            requested. Specified as lat_max lon_min lat_min lon_max
+                            requested.
+                            Specified as lat_max lon_min lat_min lon_max
                             (counterclockwise coordinates, starting at the top)
                             with longitude and latitude in the range
                             -180, +180 and -90, +90, respectively e.g.
-                            --area 90 -180 -90 180. Requests are rounded down to two
-                            decimals. Without specification, the whole available
-                            area will be returned.
+                            --area 90 -180 -90 180. Requests are rounded down
+                            to two decimals. Without specification, the whole
+                            available area will be returned.
 
                             ''')
     )

--- a/era5cli/fetch.py
+++ b/era5cli/fetch.py
@@ -31,8 +31,8 @@ class Fetch:
             Specified as [lat_max, lon_min, lat_min, lon_max]
             (counterclockwise coordinates, starting at the top),
             with longitude and latitude in the range -180, +180 and -90, +90,
-            respectively. Requests are rounded down to two decimals. Without
-            specification, the whole available area will be returned.
+            respectively. Requests are rounded down to two decimals. By
+            default, the entire available area will be returned.
         outputformat: str
             Type of file to download: 'netcdf' or 'grib'.
         outputprefix: str
@@ -297,8 +297,9 @@ class Fetch:
                 and lon_max != lon_min
                 ):
             raise ValueError(
-                "Provide coordinates as lat_max lon_min lat_min lon_max. "
-                "`lat_min`/`lat_max` must be in range -180,+180 and `lon_min`/`lon_max` must be in range -90,+90."
+                "Provide coordinates as lat_max lon_min lat_min lon_max."
+                "Latitude must be in range -180,+180 and"
+                "longitude must be in range -90,+90."
             )
 
     def _parse_area(self):

--- a/era5cli/fetch.py
+++ b/era5cli/fetch.py
@@ -298,7 +298,7 @@ class Fetch:
                 ):
             raise ValueError(
                 "Provide coordinates as lat_max lon_min lat_min lon_max. "
-                "x must be in range -180,+180 and y must be in range -90,+90."
+                "`lat_min`/`lat_max` must be in range -180,+180 and `lon_min`/`lon_max` must be in range -90,+90."
             )
 
     def _parse_area(self):

--- a/era5cli/fetch.py
+++ b/era5cli/fetch.py
@@ -28,10 +28,11 @@ class Fetch:
             List of variable names to download data for.
         area: None, list(float)
             Coordinates in case extraction of a subregion is requested.
-            Specified as [ymax, xmin, ymin, xmax], with x and y
-            in the range -180, +180 and -90, +90, respectively. Requests are
-            rounded down to two decimals. Without specification, the whole
-            available area will be returned.
+            Specified as [lat_max, lon_min, lat_min, lon_max]
+            (counterclockwise coordinates, starting at the top),
+            with longitude and latitude in the range -180, +180 and -90, +90,
+            respectively. Requests are rounded down to two decimals. Without
+            specification, the whole available area will be returned.
         outputformat: str
             Type of file to download: 'netcdf' or 'grib'.
         outputprefix: str
@@ -159,10 +160,10 @@ class Fetch:
                 self.outputformat))
 
     def _process_areaname(self):
-        (ymax, xmin, ymin, xmax) = [round(c) for c in self.area]
+        (lat_max, lon_min, lat_min, lon_max) = [round(c) for c in self.area]
         def lon(x): return f"{x}E" if x >= 0 else f"{abs(x)}W"
         def lat(y): return f"{y}N" if y >= 0 else f"{abs(y)}S"
-        name = f"_{lon(xmin)}-{lon(xmax)}_{lat(ymin)}-{lat(ymax)}"
+        name = f"_{lon(lon_min)}-{lon(lon_max)}_{lat(lat_min)}-{lat(lat_max)}"
         return name
 
     def _define_outputfilename(self, var, years):
@@ -287,16 +288,16 @@ class Fetch:
 
     def _check_area(self):
         """Confirm that area parameters are correct."""
-        (ymax, xmin, ymin, xmax) = self.area
-        if not (-90 <= ymax <= 90
-                and -90 <= ymin <= 90
-                and -180 <= xmin <= 180
-                and -180 <= xmax <= 180
-                and ymax > ymin
-                and xmax != xmin
+        (lat_max, lon_min, lat_min, lon_max) = self.area
+        if not (-90 <= lat_max <= 90
+                and -90 <= lat_min <= 90
+                and -180 <= lon_min <= 180
+                and -180 <= lon_max <= 180
+                and lat_max > lat_min
+                and lon_max != lon_min
                 ):
             raise ValueError(
-                "Provide coordinates as ymax xmin ymin xmax. "
+                "Provide coordinates as lat_max lon_min lat_min lon_max. "
                 "x must be in range -180,+180 and y must be in range -90,+90."
             )
 

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -482,7 +482,6 @@ def test_build_request():
                       years=[1970],
                       prelimbe=True)
     (name, request) = era5._build_request('total_precipitation', [1970])
-    print(request)
     assert name == (
         "reanalysis-era5-single-levels-monthly"
         "-means-preliminary-back-extension"

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -559,27 +559,27 @@ def test_area():
     (name, request) = era5._build_request('total_precipitation', [2008])
     assert request["area"] == [90.0, -179.90, -90.0, 179.01]
 
-    # ymax may not be lower than ymin
+    # lat_max may not be lower than lat_min
     with pytest.raises(ValueError):
         era5 = initialize(area=[-10, -180, 10, 180])
         era5._build_request('total_precipitation', [2008])
 
-    # xmin higher than xmax should be ok
+    # lon_min higher than lon_max should be ok
     era5 = initialize(area=[90, 120, -90, -120])
     (name, request) = era5._build_request('total_precipitation', [2008])
     assert request["area"] == [90.0, 120.0, -90.0, -120.0]
 
-    # ymax may not equal ymin
+    # lat_max may not equal lat_min
     with pytest.raises(ValueError):
         era5 = initialize(area=[0, -180, 0, 180])
         era5._build_request('total_precipitation', [2008])
 
-    # xmin may not equal xmax
+    # lon_min may not equal lon_max
     with pytest.raises(ValueError):
         era5 = initialize(area=[90, 0, -90, 0])
         era5._build_request('total_precipitation', [2008])
 
-    # ymax, xmin, ymin, xmax may not be out of bounds
+    # lat_max, lon_min, lat_min, lon_max may not be out of bounds
     with pytest.raises(ValueError):
         era5 = initialize(area=[1000, -180, -90, 180])
         era5._build_request('total_precipitation', [2008])


### PR DESCRIPTION
This PR refactors the (internally used) names of coordinate variables xmin/xmax and ymin/ymax to lon_min/lon_max and lat_min/lat_max respectively.

Furthermore, it adds explicit names to the arguments asked in the CLI with the `--area` flag: when calling

```
era5cli hourly --help
```

the returned information is:

```
usage: Use "era5cli hourly --help" for more information.

 [-h] --variables VARIABLES [VARIABLES ...] --startyear STARTYEAR [--endyear ENDYEAR] [--levels LEVELS [LEVELS ...]] [--outputprefix OUTPUTPREFIX] [--format {netcdf,grib}]
                                                           [--merge] [--threads {1,2,3,4,5,6}] [--ensemble] [--dryrun] [--prelimbe] [--land] [--area LAT_MAX LON_MIN LAT_MIN LON_MAX] [--months MONTHS [MONTHS ...]]
                                                           [--days DAYS [DAYS ...]] [--hours HOURS [HOURS ...]] [--statistics]
```
(...)
```
--area LAT_MAX LON_MIN LAT_MIN LON_MAX
                        Coordinates in case extraction of a subregion is
                        requested. Specified as lat_max lon_min lat_min lon_max
                        (counterclockwise coordinates, starting at the top)
                        with longitude and latitude in the range
                        -180, +180 and -90, +90, respectively e.g.
                        --area 90 -180 -90 180. Requests are rounded down to two
                        decimals. Without specification, the whole available
                        area will be returned.
```

Closes #74