### PR TITLE
Consistent documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,4 +59,4 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []

--- a/docs/source/instructions.rst
+++ b/docs/source/instructions.rst
@@ -83,8 +83,12 @@ Fetching hourly data
 
 Fetch hourly data through an cdsapi call via command line. More information on the available data and options can be found on:
 
-| `Era5 hourly single levels download page <https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-single-levels?tab=overview>`_.
-| `Era5 hourly pressure levels download page <https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-pressure-levels?tab=overview>`_.
+| `Era5 hourly single levels download page <https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-single-levels>`_.
+| `Era5 hourly pressure levels download page <https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-pressure-levels>`_.
+| `Era5 hourly single levels preliminary back extension download page <https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-single-levels-preliminary-back-extension>`_.
+| `Era5 hourly pressure levels preliminary back extension download page <https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-pressure-levels-preliminary-back-extension>`_.
+| `Era5-Land hourly download page <https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-land>`_.
+
 
 .. argparse::
    :module: era5cli.cli
@@ -98,10 +102,14 @@ Fetching monthly data
 
 Fetch monthly data through an cdsapi call via command line. More information on the available data and options can be found on:
 
-| `Era5 monthly single levels download page <https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-single-levels-monthly-means?tab=overview>`_.
-| `Era5 monthly pressure levels download page <https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-pressure-levels-monthly-means?tab=overview>`_.
+| `Era5 monthly single levels download page <https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-single-levels-monthly-means>`_.
+| `Era5 monthly pressure levels download page <https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-pressure-levels-monthly-means>`_.
+| `Era5 monthly single levels preliminary back extension download page <https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-single-levels-monthly-means-preliminary-back-extension>`_.
+| `Era5 monthly pressure levels preliminary back extension download page <https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-pressure-levels-monthly-means-preliminary-back-extension>`_.
+| `Era5-Land monthly download page <https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-land-monthly-means>`_.
 
-For the monthly data, some of the variables are not available. Exceptions on the single level data can be found in table 8 of 
+
+For the monthly data, some of the variables are not available. Exceptions on the single level data can be found in table 8 of
 `ERA5 parameter listings <https://confluence.ecmwf.int/display/CKB/ERA5+data+documentation#ERA5datadocumentation-Parameterlistings>`_
 
 .. argparse::
@@ -114,6 +122,6 @@ For the monthly data, some of the variables are not available. Exceptions on the
 Removing or canceling requests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-ERA-5 download requests will be saved in the `Your requests <https://cds.climate.copernicus.eu/cdsapp#!/yourrequests>`_ section in your profile on the Copernicus Climate Data Store. Here you can re-download the requested data, cancel active requests, or remove old requests. 
+ERA-5 download requests will be saved in the `Your requests <https://cds.climate.copernicus.eu/cdsapp#!/yourrequests>`_ section in your profile on the Copernicus Climate Data Store. Here you can re-download the requested data, cancel active requests, or remove old requests.
 
 Note that it is currently not possible to cancel active requests from the command line: Killing the process will not download the data to your local machine but still add it to your Copernicus account.

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -28,7 +28,7 @@ def _build_parser():
                              The variables to download data for. This can be a
                              single variable, or multiple. See the Copernicus
                              Climate Data Store website or run
-                             "era5cli info -h" for available variables.
+                             `era5cli info -h` for available variables.
 
                              ''')
     )
@@ -40,7 +40,7 @@ def _build_parser():
                              Single year or first year of range for which
                              data should be downloaded.
                              Every year will be downloaded in a separate file
-                             by default. Set "--split false" to change this.
+                             by default. Set `--split false` to change this.
 
                              ''')
     )
@@ -52,9 +52,9 @@ def _build_parser():
                              Last year of range for which data should be
                              downloaded.
                              If only a single year is needed, only
-                             "--startyear" needs to be specified.
+                             `--startyear` needs to be specified.
                              Every year will be downloaded in a separate file
-                             by default. Set "--split false" to change this.
+                             by default. Set `--split false` to change this.
 
                              ''')
     )
@@ -66,7 +66,7 @@ def _build_parser():
                              Pressure level(s) to download 3D variables for.
                              Default is all available levels.
                              See the Copernicus Climate Data Store website or
-                             run "era5cli info -h" for available pressure
+                             run `era5cli info -h` for available pressure
                              levels.
 
                              ''')
@@ -76,7 +76,7 @@ def _build_parser():
         "--outputprefix", type=str, default='era5',
         help=textwrap.dedent('''\
                              Prefix to be used for the output filename.
-                             Default prefix is "era5".
+                             Default prefix is `era5`.
 
                              ''')
     )
@@ -84,7 +84,7 @@ def _build_parser():
     common.add_argument(
         "--format", type=str, default="netcdf", choices=["netcdf", "grib"],
         help=textwrap.dedent('''\
-                             Output file type. Defaults to 'netcdf'."
+                             Output file type. Defaults to `netcdf`.
 
                              ''')
     )
@@ -114,9 +114,9 @@ def _build_parser():
         help=textwrap.dedent('''\
                              Whether to download high resolution realisation
                              (HRES) or a reduced resolution ten member ensemble
-                             (EDA). Providing the "--ensemble" argument
+                             (EDA). Providing the `--ensemble` argument
                              downloads the reduced resolution ensemble.
-                             --ensemble is incompatible with --land.
+                             `--ensemble` is incompatible with `--land`.
 
                              ''')
     )
@@ -126,7 +126,7 @@ def _build_parser():
         help=textwrap.dedent('''\
                              Whether to print the cdsapi request to the screen,
                              or make the request to start downloading the data.
-                             Providing the "--dryrun" argument will print the
+                             Providing the `--dryrun` argument will print the
                              request to stdout. By default, the data will be
                              downloaded.
 
@@ -137,10 +137,10 @@ def _build_parser():
         "--prelimbe", action="store_true", default=False,
         help=textwrap.dedent('''\
                              Whether to download the preliminary back extension
-                             (1950-1978). Note that when "--prelimbe" is used,
-                             "--startyear" and "--endyear" should be set
+                             (1950-1978). Note that when `--prelimbe` is used,
+                             `--startyear` and `--endyear` should be set
                              between 1950 and 1978.
-                             --prelimbe is incompatible with --land.
+                             `--prelimbe` is incompatible with `--land`.
 
                              ''')
     )
@@ -151,8 +151,8 @@ def _build_parser():
                              Whether to download data from the ERA5-Land
                              dataset. Note that the ERA5-Land dataset starts in
                              1981.
-                             --land is incompatible with the use of --prelimbe
-                             and --ensemble.
+                             `--land` is incompatible with the use of
+                             `--prelimbe` and `--ensemble`.
 
                              ''')
     )
@@ -164,11 +164,11 @@ def _build_parser():
         help=textwrap.dedent('''\
                             Coordinates in case extraction of a subregion is
                             requested.
-                            Specified as LAT_MAX LON_MIN LAT_MIN LON_MAX
+                            Specified as `LAT_MAX LON_MIN LAT_MIN LON_MAX`
                             (counterclockwise coordinates, starting at the top)
                             with longitude in the range -180, +180
                             and latitude in the range -90, +90. For example:
-                            --area 90 -180 -90 180. Requests are rounded down
+                            `--area 90 -180 -90 180`. Requests are rounded down
                             to two decimals. By default, the entire
                             available area will be returned.
 
@@ -221,12 +221,12 @@ def _build_parser():
         'hourly', parents=[common, mnth, day, hour],
         description='Execute the data fetch process for hourly data.',
         prog=textwrap.dedent('''\
-                             Use "era5cli hourly --help" for more information.
+                             Use `era5cli hourly --help` for more information.
 
                              '''),
         help=textwrap.dedent('''\
                              Execute the data fetch process for hourly data.
-                             Use "era5cli hourly --help" for more information.
+                             Use `era5cli hourly --help` for more information.
 
                              '''),
         formatter_class=argparse.RawTextHelpFormatter)
@@ -235,7 +235,7 @@ def _build_parser():
         "--statistics", action="store_true",
         help=textwrap.dedent('''\
                              When downloading hourly ensemble data, provide
-                             the "--statistics" argument to download statistics
+                             the `--statistics` argument to download statistics
                              (ensemble mean and ensemble spread).
 
                              ''')
@@ -245,12 +245,12 @@ def _build_parser():
         'monthly', parents=[common, mnth],
         description='Execute the data fetch process for monthly data.',
         prog=textwrap.dedent('''\
-                             Use "era5cli monthly --help" for more information.
+                             Use `era5cli monthly --help` for more information.
 
                              '''),
         help=textwrap.dedent('''\
                              Execute the data fetch process for monthly data.
-                             Use "era5cli monthly --help" for more information.
+                             Use `era5cli monthly --help` for more information.
 
                              '''),
         formatter_class=argparse.RawTextHelpFormatter
@@ -261,9 +261,9 @@ def _build_parser():
         help=textwrap.dedent('''\
                              Time of day in hours to get the synoptic means
                              (monthly averaged by hour of day) for. For example
-                             "--synoptic 0 4 5 6 23". Give empty option
-                             "--synoptic" to download all hours (0-23).
-                             The option defaults to "None" in which case the
+                             `--synoptic 0 4 5 6 23`. Give empty option
+                             `--synoptic` to download all hours (0-23).
+                             The option defaults to `None` in which case the
                              monthly average of daily means is chosen.
 
                              ''')
@@ -273,12 +273,12 @@ def _build_parser():
         'info',
         description='Show information on available variables and levels.',
         prog=textwrap.dedent('''\
-                             Use "era5cli info --help" for more information.
+                             Use `era5cli info --help` for more information.
 
                              '''),
         help=textwrap.dedent('''\
                              Show information on available variables or levels.
-                             Use "era5cli info --help" for more information.
+                             Use `era5cli info --help` for more information.
 
                              '''),
         formatter_class=argparse.RawTextHelpFormatter
@@ -288,15 +288,15 @@ def _build_parser():
         "name", type=str,
         help=textwrap.dedent('''\
                              Enter list name to print info list: \n
-                             "levels" for all available pressure levels \n
-                             "2Dvars" for all available single level or 2D
+                             `levels` for all available pressure levels \n
+                             `2Dvars` for all available single level or 2D
                              variables \n
-                             "3Dvars" for all available 3D variables \n
-                             "land" for all available variables in
+                             `3Dvars` for all available 3D variables \n
+                             `land` for all available variables in
                              ERA5-land \n
-                             Enter variable name (e.g. "total_precipitation")
-                             or pressure level (e.g. "825") to show if the
-                             variable or level is available and in which list.
+                             Enter variable name (e.g. `total_precipitation`)
+                             or pressure level (e.g. `825`) to show if the
+                             variable or level is available, and in which list.
 
                              ''')
     )

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -27,8 +27,8 @@ def _build_parser():
         help=textwrap.dedent('''\
                              The variables to download data for. This can be a
                              single variable, or multiple. See the Copernicus
-                             Climate Data Store website or run "era5cli info -h"
-                             for available variables.
+                             Climate Data Store website or run
+                             "era5cli info -h" for available variables.
 
                              ''')
     )
@@ -64,9 +64,10 @@ def _build_parser():
         required=False, default=ref.PLEVELS,
         help=textwrap.dedent('''\
                              Pressure level(s) to download 3D variables for.
-                             Default is all available levels. See the Copernicus
-                             Climate Data Store website or run "era5cli info -h"
-                             for available pressure levels.
+                             Default is all available levels.
+                             See the Copernicus Climate Data Store website or
+                             run "era5cli info -h" for available pressure
+                             levels.
 
                              ''')
     )
@@ -137,8 +138,8 @@ def _build_parser():
         help=textwrap.dedent('''\
                              Whether to download the preliminary back extension
                              (1950-1978). Note that when "--prelimbe" is used,
-                             "--startyear" and "--endyear" should be set between
-                             1950 and 1978.
+                             "--startyear" and "--endyear" should be set
+                             between 1950 and 1978.
                              --prelimbe is incompatible with --land.
 
                              ''')

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -165,8 +165,8 @@ def _build_parser():
                             requested.
                             Specified as LAT_MAX LON_MIN LAT_MIN LON_MAX
                             (counterclockwise coordinates, starting at the top)
-                            with longitude and latitude in the range
-                            -180, +180 and -90, +90, respectively e.g.
+                            with longitude in the range -180, +180
+                            and latitude in the range -90, +90. For example:
                             --area 90 -180 -90 180. Requests are rounded down
                             to two decimals. By default, the entire
                             available area will be returned.

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -25,10 +25,10 @@ def _build_parser():
     common.add_argument(
         "--variables", type=str, required=True, nargs="+",
         help=textwrap.dedent('''\
-                             The variables to be downloaded, can be a single
-                             or multiple variables. See the Copernicus Climate
-                             Data Store website or run "era5cli info -h" for
-                             available variables.
+                             The variables to download data for. This can be a
+                             single variable, or multiple. See the Copernicus
+                             Climate Data Store website or run "era5cli info -h"
+                             for available variables.
 
                              ''')
     )
@@ -38,8 +38,7 @@ def _build_parser():
         required=True,
         help=textwrap.dedent('''\
                              Single year or first year of range for which
-                             data should be downloaded (between 1979 -
-                             present).
+                             data should be downloaded.
                              Every year will be downloaded in a separate file
                              by default. Set "--split false" to change this.
 
@@ -51,7 +50,7 @@ def _build_parser():
         required=False, default=None,
         help=textwrap.dedent('''\
                              Last year of range for which data should be
-                             downloaded (between 1979 - present).
+                             downloaded.
                              If only a single year is needed, only
                              "--startyear" needs to be specified.
                              Every year will be downloaded in a separate file
@@ -64,10 +63,10 @@ def _build_parser():
         "--levels", nargs="+", type=int,
         required=False, default=ref.PLEVELS,
         help=textwrap.dedent('''\
-                             Pressure level(s) to download for three
-                             dimensional data. Default is all available
-                             levels. See the cds website or run "era5cli info
-                             -h" for available pressure levels.
+                             Pressure level(s) to download 3D variables for.
+                             Default is all available levels. See the Copernicus
+                             Climate Data Store website or run "era5cli info -h"
+                             for available pressure levels.
 
                              ''')
     )
@@ -75,8 +74,8 @@ def _build_parser():
     common.add_argument(
         "--outputprefix", type=str, default='era5',
         help=textwrap.dedent('''\
-                             Prefix of output filename. Default prefix is
-                             "era5".
+                             Prefix to be used for the output filename.
+                             Default prefix is "era5".
 
                              ''')
     )
@@ -104,7 +103,7 @@ def _build_parser():
         required=False, default=None,
         help=textwrap.dedent('''\
                              Number of parallel threads to use when
-                             downloading. Default is a single process.
+                             downloading. Defaults to a single process.
 
                              ''')
     )
@@ -116,6 +115,7 @@ def _build_parser():
                              (HRES) or a reduced resolution ten member ensemble
                              (EDA). Providing the "--ensemble" argument
                              downloads the reduced resolution ensemble.
+                             --ensemble is incompatible with --land.
 
                              ''')
     )
@@ -123,10 +123,11 @@ def _build_parser():
     common.add_argument(
         "--dryrun", action="store_true", default=False,
         help=textwrap.dedent('''\
-                             Whether to start downloading the request or just
-                             print information on the chosen parameters and
-                             output file names. Providing the "--dryrun"
-                             argument will print the information to stdout.
+                             Whether to print the cdsapi request to the screen,
+                             or make the request to start downloading the data.
+                             Providing the "--dryrun" argument will print the
+                             request to stdout. By default, the data will be
+                             downloaded.
 
                              ''')
     )
@@ -134,13 +135,11 @@ def _build_parser():
     common.add_argument(
         "--prelimbe", action="store_true", default=False,
         help=textwrap.dedent('''\
-                             Whether to download the preliminary back
-                             extension. Providing the "--prelimbe" argument
-                             downloads data from the preliminary back
-                             extension. Note that when "--prelimbe" is used,
-                             "--startyear" and "--endyear" should be set
-                             between 1950 and 1978. --prelimbe is incompatible
-                             with --land.
+                             Whether to download the preliminary back extension
+                             (1950-1978). Note that when "--prelimbe" is used,
+                             "--startyear" and "--endyear" should be set between
+                             1950 and 1978.
+                             --prelimbe is incompatible with --land.
 
                              ''')
     )
@@ -148,13 +147,11 @@ def _build_parser():
     common.add_argument(
         "--land", action="store_true", default=False,
         help=textwrap.dedent('''\
-                             Download data from ERA5-Land.
-                             Providing the "--land" argument
-                             downloads data from the ERA5-Land dataset.
-                             Note that the ERA5-Land dataset starts in
+                             Whether to download data from the ERA5-Land
+                             dataset. Note that the ERA5-Land dataset starts in
                              1981.
-                             --land is incompatible with the use of
-                             --prelimbe and --ensemble.
+                             --land is incompatible with the use of --prelimbe
+                             and --ensemble.
 
                              ''')
     )

--- a/era5cli/fetch.py
+++ b/era5cli/fetch.py
@@ -47,39 +47,40 @@ class Fetch:
             Whether to download high resolution realisation
             (HRES) or a reduced resolution ten member ensemble
             (EDA). If `True` the reduced resolution is fetched.
-            'ensemble' is incompatible with 'land'.
+            `ensemble = True` is incompatible with `land = True`.
         statistics: None, bool
             When downloading hourly ensemble data, choose
             whether or not to download statistics (ensemble mean
             and ensemble spread).
         synoptic: None, bool
             Whether to get monthly averaged by hour of day
-            (synoptic=True) or monthly means of daily means
-            (synoptic=False).
+            (`synoptic = True`) or monthly means of daily means
+            (`synoptic = False`).
         pressurelevels: None, list(int)
             List of pressure level(s) to download 3D variables for.
             See the Copernicus Climate Data Store website for available
             pressure levels.
         merge: bool
-            Merge yearly output files (merge=True), or split
+            Merge yearly output files (`merge = True`), or split
             output files into separate files for every year
-            (merge=False).
+            (`merge = False`).
         threads: None, int
             Number of parallel threads to use when downloading.
             Defaults to a single process.
         dryrun: bool
             Whether to print the cdsapi request to the screen,
             or make the request to start downloading the data.
-            A dryrun will print the request to stdout. By default,
+            `dryrun = True` will print the request to stdout. By default,
             the data will be downloaded.
         prelimbe: bool
             Whether to download the preliminary back extension (1950-1978).
-            Note that in this case, 'years' nust be between 1950 and
-            1978. 'prelimbe' is incompatible with 'land'.
+            Note that in this case, `years` nust be between 1950 and
+            1978. `prelimbe = True` is incompatible with `land = True`.
         land: bool
             Whether to download data from the ERA5-Land dataset.
             Note that the ERA5-Land dataset starts in 1981.
-            'land is incompatible with the use of 'prelimbe' and 'ensemble'.
+            `land = True` is incompatible with the use of
+            `prelimbe = True` and `ensemble = True`.
     """
 
     def __init__(self, years: list, months: list, days: list,

--- a/era5cli/fetch.py
+++ b/era5cli/fetch.py
@@ -17,57 +17,69 @@ class Fetch:
         years: list(int)
             List of years to download data for.
         months: list(int)
-            List of month to download data for (1-12).
+            List of months to download data for (1-12).
         days: list(int), None
-            List of days of month to download data for (1-31).
+            List of days of the month to download data for (1-31).
         hours: list(int)
-            List of time in hours to download data for (0-23). When downloading
-            synoptic monthly data, this parameter is used to list the synoptic
-            hours to download data for.
+            List of time of day in hours to download data for (0-23).
+            When downloading synoptic monthly data, this parameter is used
+            to list the synoptic hours to download data for.
         variables: list(str)
-            List of variable names to download data for.
+            List of variable names to download data for. See the Copernicus
+            Climate Data Store website for available variables.
         area: None, list(float)
             Coordinates in case extraction of a subregion is requested.
             Specified as [lat_max, lon_min, lat_min, lon_max]
             (counterclockwise coordinates, starting at the top),
-            with longitude and latitude in the range -180, +180 and -90, +90,
-            respectively. Requests are rounded down to two decimals. By
-            default, the entire available area will be returned.
+            with longitude in the range -180, +180
+            and latitude in the range -90, +90. For example:
+            [90, -180, -90, 180]. Requests are rounded down to
+            two decimals. By default, the entire available area
+            will be returned.
         outputformat: str
-            Type of file to download: 'netcdf' or 'grib'.
+            Output file type: 'netcdf' or 'grib'.
         outputprefix: str
             Prefix to be used for the output filename.
         period: str
-            Frequency of the data to be downloaded: 'hourly' or 'monthly'.
+            Execute the data fetch process for this data type:
+            'hourly' or 'monthly'.
         ensemble: bool
             Whether to download high resolution realisation
             (HRES) or a reduced resolution ten member ensemble
             (EDA). If `True` the reduced resolution is fetched.
+            'ensemble' is incompatible with 'land'.
         statistics: None, bool
             When downloading hourly ensemble data, choose
-            whether or not to download statistics (mean and
-            spread).
+            whether or not to download statistics (ensemble mean
+            and ensemble spread).
         synoptic: None, bool
             Whether to get monthly averaged by hour of day
             (synoptic=True) or monthly means of daily means
             (synoptic=False).
         pressurelevels: None, list(int)
-            List of pressure levels to download 3D variables for.
+            List of pressure level(s) to download 3D variables for.
+            See the Copernicus Climate Data Store website for available
+            pressure levels.
         merge: bool
             Merge yearly output files (merge=True), or split
             output files into separate files for every year
             (merge=False).
         threads: None, int
-            Number of parallel calls to cdsapi. If `None` no
-            parallel calls are done.
+            Number of parallel threads to use when downloading.
+            Defaults to a single process.
         dryrun: bool
-            Indicating if files should be downloaded. By default
-            files will be downloaded. For a dryrun the cdsapi request will
-            be written to stdout.
+            Whether to print the cdsapi request to the screen,
+            or make the request to start downloading the data.
+            A dryrun will print the request to stdout. By default,
+            the data will be downloaded.
         prelimbe: bool
             Whether to download the preliminary back extension (1950-1978).
+            Note that in this case, 'years' nust be between 1950 and
+            1978. 'prelimbe' is incompatible with 'land'.
         land: bool
-            Whether to download ERA5-Land data.
+            Whether to download data from the ERA5-Land dataset.
+            Note that the ERA5-Land dataset starts in 1981.
+            'land is incompatible with the use of 'prelimbe' and 'ensemble'.
     """
 
     def __init__(self, years: list, months: list, days: list,
@@ -84,7 +96,7 @@ class Fetch:
         else:
             self.days = era5cli.utils._zpad_days(days)
             """list(str): List of zero-padded strings of days
-            (e.g. ['01', '02',..., '12'])."""
+            (e.g. ['01', '02',..., '31'])."""
 
         self.hours = era5cli.utils._format_hours(hours)
         """list(str): List of xx:00 formatted time strings


### PR DESCRIPTION
This PR tries to make the documentation between the CLI and the Fetch class more consistent, also making it easier to apply future changes in both sites.
Links to the back extension and Era5 land are also added (these had so far been missing from the docs), plus some minor changes (like trailing spaces removed).

Closes #71 