### PR TITLE
documentation badge set to 'stable'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ era5cli
     :target: https://opensource.org/licenses/Apache-2.0
     :alt: License
 
-.. image:: https://img.shields.io/badge/docs-latest-brightgreen.svg
-   :target: http://era5cli.readthedocs.io/en/latest/?badge=latest
+.. image:: https://img.shields.io/badge/docs-stable-brightgreen.svg
+   :target: http://era5cli.readthedocs.io/en/stable/?badge=stable
    :alt: Documentation Status
 
 .. image:: https://github.com/eWaterCycle/era5cli/actions/workflows/test_codecov.yml/badge.svg


### PR DESCRIPTION
The default readthedocs is now set to the 'stable' version, i.e. latest github release.
This PR matches the badge on the README to this version.