### PR TITLE
add a badge for howfairis score

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,9 @@ era5cli
    :target: https://www.research-software.nl/software/era5cli
    :alt: Research Software Directory Badge
 
+.. image:: https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8B-yellow
+   :target: https://fair-software.eu
+   
 .. inclusion-marker-start-do-not-remove
 
 A command line interface to download ERA5 data from the `Copernicus Climate Data Store <https://climate.copernicus.eu/>`_.


### PR DESCRIPTION
After running [`howfairis`](https://github.com/fair-software/howfairis):
```
howfairis https://github.com/eWaterCycle/era5cli/
```

We get a score of 4/5 for:

```
(1/5) repository
      ✓ has_open_repository
(2/5) license
      ✓ has_license
(3/5) registry
      × has_ascl_badge
      × has_bintray_badge
      × has_conda_badge
      × has_cran_badge
      × has_crates_badge
      × has_maven_badge
      × has_npm_badge
      ✓ has_pypi_badge
      ✓ has_rsd_badge
      × is_on_github_marketplace
(4/5) citation
      × has_citation_file
      ✓ has_citationcff_file
      × has_codemeta_file
      ✓ has_zenodo_badge
      ✓ has_zenodo_metadata_file
(5/5) checklist
      × has_core_infrastructures_badge
```

This badge shows the `howfairis` score on the readme.