### PR TITLE
Add integration testing

### DIFF
--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -428,7 +428,7 @@ def _execute(args):
 def main(argv=None):
     """Main."""
     # get arguments
-    if argv == None:
+    if argv is None:
         argv = sys.argv
     args = _parse_args(argv[1:])
     _execute(args)

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -425,10 +425,12 @@ def _execute(args):
         return True
 
 
-def main():
+def main(argv=None):
     """Main."""
     # get arguments
-    args = _parse_args(sys.argv[1:])
+    if argv == None:
+        argv = sys.argv
+    args = _parse_args(argv[1:])
     _execute(args)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-"""Tests for era5cli utility functios."""
+"""Tests for era5cli utility functions."""
 
 import unittest.mock as mock
 import pytest

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,8 +3,9 @@
 import logging
 import pytest
 
-import era5cli.cli as cli
 from textwrap import dedent
+
+from era5cli.cli import main
 
 
 # combine calls with result and possible warning message, in that order
@@ -115,7 +116,7 @@ def test_main(call, result, warn, capsys, caplog):
     if '--dryrun' not in call:
         pytest.fail('call must be a dryrun')
     with caplog.at_level(logging.INFO):
-        cli.main(call)
+        main(call)
     captured = capsys.readouterr().out
     assert result == captured
     assert warn in caplog.text

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -67,7 +67,8 @@ call_result = [
             '04', '05', '06', '07', '08', '09', '10', '11', '12', '13', '14',
             '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25',
             '26', '27', '28', '29', '30', '31']}
-            era5_geopotential_2008_hourly.nc""")
+            era5_geopotential_2008_hourly.nc"""),
+        "warn": "Getting variable from pressure level data."
     },
     {
         # preliminary-back-extension is combined with monthly-means
@@ -124,4 +125,4 @@ def test_main(call_result, capsys, caplog):
         warn = call_result["warn"]
         assert warn in caplog.text
     except KeyError:
-        assert caplog.text is ''
+        assert caplog.text == ''

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -91,7 +91,12 @@ call_result = [
     )
 ]
 
-ids = [call[0] for call in call_result]
+def clean_ids(call):
+    call = call.replace('\n', ' ')
+    call = call.replace('--dryrun','')
+    return(call)
+
+ids = [clean_ids(call[0]) for call in call_result]
 
 
 @pytest.mark.parametrize("call,result", call_result, ids=ids)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,79 +3,94 @@
 import pytest
 
 import era5cli.cli as cli
+from textwrap import dedent
 
 
-# geopotential needs '--levels surface' to be correctly interpreted
-call1 = """era5cli hourly --variables geopotential --startyear 2008 --dryrun
---levels surface"""
-
-result1 = """reanalysis-era5-single-levels {'variable': 'geopotential', 'year':
-2008, 'month': ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10',
-'11', '12'], 'time': ['00:00', '01:00', '02:00', '03:00', '04:00', '05:00',
-'06:00', '07:00', '08:00', '09:00', '10:00', '11:00', '12:00', '13:00',
-'14:00', '15:00', '16:00', '17:00', '18:00', '19:00', '20:00', '21:00',
-'22:00', '23:00'], 'format': 'netcdf', 'product_type': 'reanalysis', 'day':
-['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12', '13',
-'14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26',
-'27', '28', '29', '30', '31']} era5_geopotential_2008_hourly.nc"""
-
-# orography is translated to geopotential in the query
-call2 = """era5cli hourly --variables orography --startyear 2008 --dryrun"""
-
-result2 = """reanalysis-era5-single-levels {'variable': 'geopotential', 'year':
-2008, 'month': ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10',
-'11', '12'], 'time': ['00:00', '01:00', '02:00', '03:00', '04:00', '05:00',
-'06:00', '07:00', '08:00', '09:00', '10:00', '11:00', '12:00', '13:00',
-'14:00', '15:00', '16:00', '17:00', '18:00', '19:00', '20:00', '21:00',
-'22:00', '23:00'], 'format': 'netcdf', 'product_type': 'reanalysis', 'day':
-['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12', '13',
-'14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26',
-'27', '28', '29', '30', '31']} era5_orography_2008_hourly.nc"""
-
-# without --levels surface, geopotential calls pressure level data
-call3 = """era5cli hourly --variables geopotential --startyear 2008 --dryrun"""
-
-result3 = """reanalysis-era5-pressure-levels {'variable': 'geopotential',
-'year': 2008, 'month': ['01', '02', '03', '04', '05', '06', '07', '08', '09',
-'10', '11', '12'], 'time': ['00:00', '01:00', '02:00', '03:00', '04:00',
-'05:00', '06:00', '07:00', '08:00', '09:00', '10:00', '11:00', '12:00',
-'13:00', '14:00', '15:00', '16:00', '17:00', '18:00', '19:00', '20:00',
-'21:00', '22:00', '23:00'], 'format': 'netcdf', 'pressure_level': [1, 2, 3, 5,
-7, 10, 20, 30, 50, 70, 100, 125, 150, 175, 200, 225, 250, 300, 350, 400, 450,
-500, 550, 600, 650, 700, 750, 775, 800, 825, 850, 875, 900, 925, 950, 975,
-1000], 'product_type': 'reanalysis', 'day': ['01', '02', '03', '04', '05',
-'06', '07', '08', '09', '10', '11', '12', '13', '14', '15', '16', '17', '18',
-'19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31']}
-era5_geopotential_2008_hourly.nc"""
-
-# preliminary-back-extension is combined with monthly-means
-call4 = """era5cli monthly --variables temperature --startyear 1960 --prelimbe
---dryrun"""
-
-result4 = """reanalysis-era5-pressure-levels-monthly-means-preliminary-back-extension
-{'variable': 'temperature', 'year': 1960, 'month': ['01', '02', '03', '04',
-'05', '06', '07', '08', '09', '10', '11', '12'], 'time': ['00:00'], 'format':
-'netcdf', 'pressure_level': [1, 2, 3, 5, 7, 10, 20, 30, 50, 70, 100, 125, 150,
-175, 200, 225, 250, 300, 350, 400, 450, 500, 550, 600, 650, 700, 750, 775, 800,
-825, 850, 875, 900, 925, 950, 975, 1000], 'product_type':
-'reanalysis-monthly-means-of-daily-means'} era5_temperature_1960_monthly.nc"""
-
-# era5-Land is combined with monthly means
-call5 = """era5cli monthly --variables snow_cover --startyear 2008 --land
---dryrun"""
-
-result5 = """reanalysis-era5-land-monthly-means {'variable': 'snow_cover',
-'year': 2008, 'month': ['01', '02', '03', '04', '05', '06', '07', '08', '09',
-'10', '11', '12'], 'time': ['00:00'], 'format': 'netcdf', 'product_type':
-'monthly_averaged_reanalysis'} era5-land_snow_cover_2008_monthly.nc"""
-
+# combine calls with result
 call_result = [
-    (call1, result1),
-    (call2, result2),
-    (call3, result3),
-    (call4, result4),
-    (call5, result5)
-    ]
+    (
+        # geopotential needs '--levels surface' to be correctly interpreted
+        dedent("""\
+            era5cli hourly --variables geopotential --startyear 2008 --dryrun
+            --levels surface"""),
+        dedent("""\
+            reanalysis-era5-single-levels {'variable': 'geopotential', 'year':
+            2008, 'month': ['01', '02', '03', '04', '05', '06', '07', '08',
+            '09', '10', '11', '12'], 'time': ['00:00', '01:00', '02:00',
+            '03:00', '04:00', '05:00', '06:00', '07:00', '08:00', '09:00',
+            '10:00', '11:00', '12:00', '13:00', '14:00', '15:00', '16:00',
+            '17:00', '18:00', '19:00', '20:00', '21:00', '22:00', '23:00'],
+            'format': 'netcdf', 'product_type': 'reanalysis', 'day': ['01',
+            '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12',
+            '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23',
+            '24', '25', '26', '27', '28', '29', '30', '31']}
+            era5_geopotential_2008_hourly.nc""")
+    ),
+    (
+        # orography is translated to geopotential in the query
+        "era5cli hourly --variables orography --startyear 2008 --dryrun",
+        dedent("""\
+            reanalysis-era5-single-levels {'variable': 'geopotential', 'year':
+            2008, 'month': ['01', '02', '03', '04', '05', '06', '07', '08',
+            '09', '10', '11', '12'], 'time': ['00:00', '01:00', '02:00',
+            '03:00', '04:00', '05:00', '06:00', '07:00', '08:00', '09:00',
+            '10:00', '11:00', '12:00', '13:00', '14:00', '15:00', '16:00',
+            '17:00', '18:00', '19:00', '20:00', '21:00', '22:00', '23:00'],
+            'format': 'netcdf', 'product_type': 'reanalysis', 'day': ['01',
+            '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12',
+            '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23',
+            '24', '25', '26', '27', '28', '29', '30', '31']}
+            era5_orography_2008_hourly.nc""")
+    ),
+    (
+        # without --levels surface, geopotential calls pressure level data
+        "era5cli hourly --variables geopotential --startyear 2008 --dryrun",
+        dedent("""\
+            reanalysis-era5-pressure-levels {'variable': 'geopotential',
+            'year': 2008, 'month': ['01', '02', '03', '04', '05', '06', '07',
+            '08', '09', '10', '11', '12'], 'time': ['00:00', '01:00', '02:00',
+            '03:00', '04:00', '05:00', '06:00', '07:00', '08:00', '09:00',
+            '10:00', '11:00', '12:00', '13:00', '14:00', '15:00', '16:00',
+            '17:00', '18:00', '19:00', '20:00', '21:00', '22:00', '23:00'],
+            'format': 'netcdf', 'pressure_level': [1, 2, 3, 5, 7, 10, 20, 30,
+            50, 70, 100, 125, 150, 175, 200, 225, 250, 300, 350, 400, 450, 500,
+            550, 600, 650, 700, 750, 775, 800, 825, 850, 875, 900, 925, 950,
+            975, 1000], 'product_type': 'reanalysis', 'day': ['01', '02', '03',
+            '04', '05', '06', '07', '08', '09', '10', '11', '12', '13', '14',
+            '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25',
+            '26', '27', '28', '29', '30', '31']}
+            era5_geopotential_2008_hourly.nc""")
+    ),
+    (
+        # preliminary-back-extension is combined with monthly-means
+        dedent("""\
+            era5cli monthly --variables temperature --startyear 1960 --prelimbe
+            --dryrun"""),
+        dedent("""\
+            reanalysis-era5-pressure-levels-monthly-means-preliminary-back-extension
+            {'variable': 'temperature', 'year': 1960, 'month': ['01', '02',
+            '03', '04', '05', '06', '07', '08', '09', '10', '11', '12'],
+            'time': ['00:00'], 'format': 'netcdf', 'pressure_level': [1, 2, 3,
+            5, 7, 10, 20, 30, 50, 70, 100, 125, 150, 175, 200, 225, 250, 300,
+            350, 400, 450, 500, 550, 600, 650, 700, 750, 775, 800, 825, 850,
+            875, 900, 925, 950, 975, 1000], 'product_type':
+            'reanalysis-monthly-means-of-daily-means'}
+            era5_temperature_1960_monthly.nc""")
+    ),
+    (
+        # era5-Land is combined with monthly means
+        dedent("""\
+            era5cli monthly --variables snow_cover --startyear 2008 --land
+            --dryrun"""),
+        dedent("""\
+            reanalysis-era5-land-monthly-means {'variable': 'snow_cover',
+            'year': 2008, 'month': ['01', '02', '03', '04', '05', '06', '07',
+            '08', '09', '10', '11', '12'], 'time': ['00:00'], 'format':
+            'netcdf', 'product_type': 'monthly_averaged_reanalysis'}
+            era5-land_snow_cover_2008_monthly.nc""")
+    )
+]
+
 ids = [call[0] for call in call_result]
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,6 +5,7 @@ import pytest
 import era5cli.cli as cli
 
 
+# geopotential needs '--levels surface' to be correctly interpreted
 call1 = """era5cli hourly --variables geopotential --startyear 2008 --dryrun
 --levels surface"""
 
@@ -18,8 +19,8 @@ result1 = """reanalysis-era5-single-levels {'variable': 'geopotential', 'year':
 '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26',
 '27', '28', '29', '30', '31']} era5_geopotential_2008_hourly.nc"""
 
-call2 = """era5cli hourly --variables orography --startyear 2008 --dryrun
---levels surface"""
+# orography is translated to geopotential in the query
+call2 = """era5cli hourly --variables orography --startyear 2008 --dryrun"""
 
 result2 = """reanalysis-era5-single-levels {'variable': 'geopotential', 'year':
 2008, 'month': ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10',
@@ -31,8 +32,28 @@ result2 = """reanalysis-era5-single-levels {'variable': 'geopotential', 'year':
 '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26',
 '27', '28', '29', '30', '31']} era5_orography_2008_hourly.nc"""
 
+# without --levels surface, geopotential calls pressure level data
+call3 = """era5cli hourly --variables geopotential --startyear 2008 --dryrun"""
 
-call_result = [(call1, result1), (call2, result2)]
+result3 = """reanalysis-era5-pressure-levels {'variable': 'geopotential',
+'year': 2008, 'month': ['01', '02', '03', '04', '05', '06', '07', '08', '09',
+'10', '11', '12'], 'time': ['00:00', '01:00', '02:00', '03:00', '04:00',
+'05:00', '06:00', '07:00', '08:00', '09:00', '10:00', '11:00', '12:00',
+'13:00', '14:00', '15:00', '16:00', '17:00', '18:00', '19:00', '20:00',
+'21:00', '22:00', '23:00'], 'format': 'netcdf', 'pressure_level': [1, 2, 3, 5,
+7, 10, 20, 30, 50, 70, 100, 125, 150, 175, 200, 225, 250, 300, 350, 400, 450,
+500, 550, 600, 650, 700, 750, 775, 800, 825, 850, 875, 900, 925, 950, 975,
+1000], 'product_type': 'reanalysis', 'day': ['01', '02', '03', '04', '05',
+'06', '07', '08', '09', '10', '11', '12', '13', '14', '15', '16', '17', '18',
+'19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31']}
+era5_geopotential_2008_hourly.nc"""
+
+
+call_result = [
+    (call1, result1),
+    (call2, result2),
+    (call3, result3)
+    ]
 ids = [call[0] for call in call_result]
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,49 @@
+"""Tests to check the full era5cli workflow."""
+
+import pytest
+
+import era5cli.cli as cli
+
+
+call1 = """era5cli hourly --variables geopotential --startyear 2008 --dryrun
+--levels surface"""
+
+result1 = """reanalysis-era5-single-levels {'variable': 'geopotential', 'year':
+2008, 'month': ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10',
+'11', '12'], 'time': ['00:00', '01:00', '02:00', '03:00', '04:00', '05:00',
+'06:00', '07:00', '08:00', '09:00', '10:00', '11:00', '12:00', '13:00',
+'14:00', '15:00', '16:00', '17:00', '18:00', '19:00', '20:00', '21:00',
+'22:00', '23:00'], 'format': 'netcdf', 'product_type': 'reanalysis', 'day':
+['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12', '13',
+'14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26',
+'27', '28', '29', '30', '31']} era5_geopotential_2008_hourly.nc"""
+
+call2 = """era5cli hourly --variables orography --startyear 2008 --dryrun
+--levels surface"""
+
+result2 = """reanalysis-era5-single-levels {'variable': 'geopotential', 'year':
+2008, 'month': ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10',
+'11', '12'], 'time': ['00:00', '01:00', '02:00', '03:00', '04:00', '05:00',
+'06:00', '07:00', '08:00', '09:00', '10:00', '11:00', '12:00', '13:00',
+'14:00', '15:00', '16:00', '17:00', '18:00', '19:00', '20:00', '21:00',
+'22:00', '23:00'], 'format': 'netcdf', 'product_type': 'reanalysis', 'day':
+['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12', '13',
+'14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26',
+'27', '28', '29', '30', '31']} era5_orography_2008_hourly.nc"""
+
+
+call_result = [(call1, result1), (call2, result2)]
+ids = [call[0] for call in call_result]
+
+
+@pytest.mark.parametrize("call,result", call_result, ids=ids)
+def test_main(call, result, capsys):
+    call = call.split()
+    # until the actual fetch is monkeypatched, make sure the tests are dryruns
+    if '--dryrun' not in call:
+        pytest.fail('call must be a dryrun')
+    cli.main(call)
+    captured = capsys.readouterr().out
+    result = result.replace('\n', ' ')
+    result = result + '\n'
+    assert result == captured

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,6 +9,22 @@ from textwrap import dedent
 # combine calls with result
 call_result = [
     (
+        # orography is translated to geopotential in the query
+        "era5cli hourly --variables orography --startyear 2008 --dryrun",
+        dedent("""\
+            reanalysis-era5-single-levels {'variable': 'geopotential', 'year':
+            2008, 'month': ['01', '02', '03', '04', '05', '06', '07', '08',
+            '09', '10', '11', '12'], 'time': ['00:00', '01:00', '02:00',
+            '03:00', '04:00', '05:00', '06:00', '07:00', '08:00', '09:00',
+            '10:00', '11:00', '12:00', '13:00', '14:00', '15:00', '16:00',
+            '17:00', '18:00', '19:00', '20:00', '21:00', '22:00', '23:00'],
+            'format': 'netcdf', 'product_type': 'reanalysis', 'day': ['01',
+            '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12',
+            '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23',
+            '24', '25', '26', '27', '28', '29', '30', '31']}
+            era5_orography_2008_hourly.nc""")
+    ),
+    (
         # geopotential needs '--levels surface' to be correctly interpreted
         dedent("""\
             era5cli hourly --variables geopotential --startyear 2008 --dryrun
@@ -25,22 +41,6 @@ call_result = [
             '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23',
             '24', '25', '26', '27', '28', '29', '30', '31']}
             era5_geopotential_2008_hourly.nc""")
-    ),
-    (
-        # orography is translated to geopotential in the query
-        "era5cli hourly --variables orography --startyear 2008 --dryrun",
-        dedent("""\
-            reanalysis-era5-single-levels {'variable': 'geopotential', 'year':
-            2008, 'month': ['01', '02', '03', '04', '05', '06', '07', '08',
-            '09', '10', '11', '12'], 'time': ['00:00', '01:00', '02:00',
-            '03:00', '04:00', '05:00', '06:00', '07:00', '08:00', '09:00',
-            '10:00', '11:00', '12:00', '13:00', '14:00', '15:00', '16:00',
-            '17:00', '18:00', '19:00', '20:00', '21:00', '22:00', '23:00'],
-            'format': 'netcdf', 'product_type': 'reanalysis', 'day': ['01',
-            '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12',
-            '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23',
-            '24', '25', '26', '27', '28', '29', '30', '31']}
-            era5_orography_2008_hourly.nc""")
     ),
     (
         # without --levels surface, geopotential calls pressure level data

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -48,11 +48,33 @@ result3 = """reanalysis-era5-pressure-levels {'variable': 'geopotential',
 '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31']}
 era5_geopotential_2008_hourly.nc"""
 
+# preliminary-back-extension is combined with monthly-means
+call4 = """era5cli monthly --variables temperature --startyear 1960 --prelimbe
+--dryrun"""
+
+result4 = """reanalysis-era5-pressure-levels-monthly-means-preliminary-back-extension
+{'variable': 'temperature', 'year': 1960, 'month': ['01', '02', '03', '04',
+'05', '06', '07', '08', '09', '10', '11', '12'], 'time': ['00:00'], 'format':
+'netcdf', 'pressure_level': [1, 2, 3, 5, 7, 10, 20, 30, 50, 70, 100, 125, 150,
+175, 200, 225, 250, 300, 350, 400, 450, 500, 550, 600, 650, 700, 750, 775, 800,
+825, 850, 875, 900, 925, 950, 975, 1000], 'product_type':
+'reanalysis-monthly-means-of-daily-means'} era5_temperature_1960_monthly.nc"""
+
+# era5-Land is combined with monthly means
+call5 = """era5cli monthly --variables snow_cover --startyear 2008 --land
+--dryrun"""
+
+result5 = """reanalysis-era5-land-monthly-means {'variable': 'snow_cover',
+'year': 2008, 'month': ['01', '02', '03', '04', '05', '06', '07', '08', '09',
+'10', '11', '12'], 'time': ['00:00'], 'format': 'netcdf', 'product_type':
+'monthly_averaged_reanalysis'} era5-land_snow_cover_2008_monthly.nc"""
 
 call_result = [
     (call1, result1),
     (call2, result2),
-    (call3, result3)
+    (call3, result3),
+    (call4, result4),
+    (call5, result5)
     ]
 ids = [call[0] for call in call_result]
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -124,4 +124,4 @@ def test_main(call_result, capsys, caplog):
         warn = call_result["warn"]
         assert warn in caplog.text
     except KeyError:
-        pass
+        assert caplog.text is ''

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -82,11 +82,10 @@ ids = [call[0] for call in call_result]
 @pytest.mark.parametrize("call,result", call_result, ids=ids)
 def test_main(call, result, capsys):
     call = call.split()
+    result = result.replace('\n', ' ') + '\n'
     # until the actual fetch is monkeypatched, make sure the tests are dryruns
     if '--dryrun' not in call:
         pytest.fail('call must be a dryrun')
     cli.main(call)
     captured = capsys.readouterr().out
-    result = result.replace('\n', ' ')
-    result = result + '\n'
     assert result == captured

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -91,10 +91,12 @@ call_result = [
     )
 ]
 
+
 def clean_ids(call):
     call = call.replace('\n', ' ')
-    call = call.replace('--dryrun','')
+    call = call.replace('--dryrun', '')
     return(call)
+
 
 ids = [clean_ids(call[0]) for call in call_result]
 


### PR DESCRIPTION
This PR adds a backbone for integration tests to the tool. It does not test the actual fetch from Copernicus, but it tests whether the workflow functions as expected, and creates the correct query from an era5cli call with the `--dryrun` option.

Closes #100 