### PR TITLE
Updates for v1.3.0 according to contribution guidelines

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Release Notes
 *************
 
+1.3.0 (2021-11-30)
+~~~~~~~~~~~~~~~~~~
+* Fix compatibility with changed CDS variables geopotential/orography `#98 <https://github.com/eWaterCycle/era5cli/pull/98>`_
+* Add integration testing `#102 <https://github.com/eWaterCycle/era5cli/pull/102>`_
+
 1.2.1 (2021-04-21)
 ~~~~~~~~~~~~~~~~~~
 * Automatic PyPI release for 1.2.0 failed; updated github action workflow `#91 <https://github.com/eWaterCycle/era5cli/pull/91>`_

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -78,8 +78,8 @@ authors:
     given-names: Stefan
     orcid: 0000-0002-5821-2060
 
-cff-version: "1.0.3"
-date-released: 2021-04-21
+cff-version: "1.0.4"
+date-released: 2021-11-30
 doi: 10.5281/zenodo.3252665
 keywords:
   - "ERA5"
@@ -87,4 +87,4 @@ license: Apache-2.0
 message: "If you use this software, please cite it using these metadata."
 repository-code: "https://github.com/ewatercycle/era5cli"
 title: era5cli
-version: 1.2.1
+version: 1.3.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -78,7 +78,7 @@ authors:
     given-names: Stefan
     orcid: 0000-0002-5821-2060
 
-cff-version: "1.0.4"
+cff-version: "1.0.3"
 date-released: 2021-11-30
 doi: 10.5281/zenodo.3252665
 keywords:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,11 @@ Open [releases](https://github.com/eWaterCycle/era5cli/releases) and draft a new
 release. Copy the changelog for this version into the description (though note
 that the description is in Markdown, so reformat from Rst if necessary).
 
-Tag the release according to semantic versioning guidelines, preceded with a `v`
-(e.g.: v1.0.0). The release title is the tag and the release date together
-(e.g.: v1.0.0 (2019-07-25)). Tick the pre-release box in case the release is a
-candidate release, and amend the version tag with `rc` and the candidate number.
+Tag the release according to [semantic versioning
+guidelines](https://semver.org/), preceded with a `v` (e.g.: v1.0.0). The
+release title is the tag and the release date together (e.g.: v1.0.0
+(2019-07-25)). Tick the pre-release box in case the release is a candidate
+release, and amend the version tag with `rc` and the candidate number.
 
 ## PyPI release workflow
 Publishing a new release in github triggers the github Action workflow that

--- a/era5cli/__version__.py
+++ b/era5cli/__version__.py
@@ -12,4 +12,4 @@ __author__ = ('Ronald van Haren', 'Jaro Camphuijsen', 'Yifat Dzigan',
               'Peter Kalverla', 'Barbara Vreede', 'Aytaç Paçal', 'Stef Smeets',
               'Stefan Verhoeven')
 __email__ = 'ewatercycle@esciencecenter.nl'
-__version__ = '1.2.1'
+__version__ = '1.3.0'


### PR DESCRIPTION
- version number updated in `CITATION.cff` and `__version__.py`
- changelog updated with info from PR #98 and #102 

Ready for new release.