### PR TITLE
fix CI badge

### DIFF
--- a/.github/workflows/test_codecov.yml
+++ b/.github/workflows/test_codecov.yml
@@ -1,7 +1,10 @@
 name: CI test and coverage
 
 on:
-  pull_request
+  push:
+    branch: master
+  pull_request:
+    branch: master
 
 jobs:
   build:


### PR DESCRIPTION
The badge showing CI status on README refers to the last time the action was run, not to the CI status on the master branch. Actions are only run on PR, so this makes sense. This PR should fix that and reflect CI status of the master branch.

Closes #103 