### PR TITLE
update contribution guidelines and prepare for v1.3.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Release Notes
 *************
 
+1.3.1 (2021-12-01)
+~~~~~~~~~~~~~~~~~~
+* Automatic Zenodo/RSD release failed; updated contribution guidelines `#106 <https://github.com/eWaterCycle/era5cli/pull/106>`_
+
 1.3.0 (2021-11-30)
 ~~~~~~~~~~~~~~~~~~
 * Fix compatibility with changed CDS variables geopotential/orography `#98 <https://github.com/eWaterCycle/era5cli/pull/98>`_

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -87,4 +87,4 @@ license: Apache-2.0
 message: "If you use this software, please cite it using these metadata."
 repository-code: "https://github.com/ewatercycle/era5cli"
 title: era5cli
-version: 1.3.0
+version: 1.3.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ release title is the tag and the release date together (e.g.: v1.0.0
 When releasing a release candidate on Github, tick the pre-release box, and
 amend the version tag with `-rc` and the candidate number. Ensure the release
 candidate version is accurate in `CITATION.cff` and `era5cli/__version__.py`.
-If the version number in these files is not updated, Zenodo and RSD release
+If the version number in these files is not updated, Zenodo release
 workflows will fail.
 
 Releasing a release candidate is not required, but can help detect bugs early.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ builds and publishes the package to test.PyPI or PyPI. Versions with "rc"
 Other version tags will trigger a PyPI release. Inspect
 `.github/workflows/publish-to-pypi.yml` for more information.
 
-Confirm a pre-release on test.PyPI with:
+Confirm a release candidate on test.PyPI with:
 ```
 pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ era5cli
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,8 @@ Ensure all authors are present in:
 - `era5cli/__version__.py`
 
 ## Confirm release info
-Ensure the right date and upcoming version number is set in:
+Ensure the right date and upcoming version number (including release candidate
+tag, if applicable) is set in:
 
 - `CITATION.cff`
 - `era5cli/__version__.py`
@@ -40,8 +41,9 @@ release title is the tag and the release date together (e.g.: v1.0.0
 ### Release candidate
 When releasing a release candidate on Github, tick the pre-release box, and
 amend the version tag with `rc` and the candidate number. Ensure the release
-candidate version is accurate in `CHANGELOG.rst`. If the version number in this
-file is not updated, Zenodo and RSD release workflows will fail.
+candidate version is accurate in `CITATION.cff` and `era5cli/__version__.py`.
+If the version number in these files is not updated, Zenodo and RSD release
+workflows will fail.
 
 Releasing a release candidate is not required, but can help detect bugs early.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ release title is the tag and the release date together (e.g.: v1.0.0
 
 ### Release candidate
 When releasing a release candidate on Github, tick the pre-release box, and
-amend the version tag with `rc` and the candidate number. Ensure the release
+amend the version tag with `-rc` and the candidate number. Ensure the release
 candidate version is accurate in `CITATION.cff` and `era5cli/__version__.py`.
 If the version number in these files is not updated, Zenodo and RSD release
 workflows will fail.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,15 +35,22 @@ that the description is in Markdown, so reformat from Rst if necessary).
 Tag the release according to [semantic versioning
 guidelines](https://semver.org/), preceded with a `v` (e.g.: v1.0.0). The
 release title is the tag and the release date together (e.g.: v1.0.0
-(2019-07-25)). Tick the pre-release box in case the release is a candidate
-release, and amend the version tag with `rc` and the candidate number.
+(2019-07-25)).
+
+### Release candidate
+When releasing a release candidate on Github, tick the pre-release box, and
+amend the version tag with `rc` and the candidate number. Ensure the release
+candidate version is accurate in `CHANGELOG.rst`. If the version number in this
+file is not updated, Zenodo and RSD release workflows will fail.
+
+Releasing a release candidate is not required, but can help detect bugs early.
 
 ## PyPI release workflow
 Publishing a new release in github triggers the github Action workflow that
 builds and publishes the package to test.PyPI or PyPI. Versions with "rc"
-(releasecandidate) in their version tag will only be published to test.PyPI.
-Other version tags will trigger a PyPI release.
-Inspect `.github/workflows/publish-to-pypi.yml` for more information.
+(release candidate) in their version tag will only be published to test.PyPI.
+Other version tags will trigger a PyPI release. Inspect
+`.github/workflows/publish-to-pypi.yml` for more information.
 
 Confirm a pre-release on test.PyPI with:
 ```

--- a/era5cli/__version__.py
+++ b/era5cli/__version__.py
@@ -12,4 +12,4 @@ __author__ = ('Ronald van Haren', 'Jaro Camphuijsen', 'Yifat Dzigan',
               'Peter Kalverla', 'Barbara Vreede', 'Aytaç Paçal', 'Stef Smeets',
               'Stefan Verhoeven')
 __email__ = 'ewatercycle@esciencecenter.nl'
-__version__ = '1.3.0'
+__version__ = '1.3.1'


### PR DESCRIPTION
To ensure the correct version is pushed to Zenodo and the RSD, the version number needs to be updated. This is done, and made explicit in the contribution guidelines, in this PR.