### PR TITLE
update manifest and installation instructions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
-# Include the license file
+include CITATION.cff
 include LICENSE
+include CHANGELOG.rst
+include requirements.txt

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -10,9 +10,21 @@ To install from PyPI, the following command can be used:
 
    pip install era5cli
 
+Install with conda
+~~~~~~~~~~~~~~~~~~
+era5cli has been packaged for conda-forge. It can be installed from there with:
+::
+
+   conda install era5cli -c conda-forge
+
+The current version that will be installed via conda-forge is:
+
+.. image:: https://anaconda.org/conda-forge/era5cli/badges/version.svg
+  :target: https://anaconda.org/conda-forge/era5cli
+
 Install from GitHub
 ~~~~~~~~~~~~~~~~~~~
-To install directly from GitHub, the following command can be used:
+The development version is available via GitHub. To install directly from GitHub, the following command can be used:
 ::
 
    pip install -U  git+https://github.com/eWaterCycle/era5cli.git


### PR DESCRIPTION
We were alerted by @zklaus to the fact that elements were missing from the source distribution, making it not installable (see #112, #113). These have been added in this PR.

To test, make a source distribution, and install it:
```
python setup.py sdist
pip install dist/era5cli-1.3.1.tar.gz --user 
```

Closes #112
Closes #113

In addition, the current version was packaged for conda-forge by @zklaus (see #114). The installation instructions in the documentation have been updated to include this installation option.

Closes #114