### PR TITLE
fix CI badge (PR to main)

### DIFF
--- a/.github/workflows/test_codecov.yml
+++ b/.github/workflows/test_codecov.yml
@@ -2,9 +2,9 @@ name: CI test and coverage
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/test_codecov.yml
+++ b/.github/workflows/test_codecov.yml
@@ -2,9 +2,9 @@ name: CI test and coverage
 
 on:
   push:
-    branch: master
+    branches: [master]
   pull_request:
-    branch: master
+    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/test_codecov.yml
+++ b/.github/workflows/test_codecov.yml
@@ -1,7 +1,10 @@
 name: CI test and coverage
 
 on:
-  pull_request
+  push:
+    branch: master
+  pull_request:
+    branch: master
 
 jobs:
   build:

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ era5cli
    :target: https://github.com/eWaterCycle/era5cli/actions/workflows/test_codecov.yml
    :alt: Github Actions
 
-.. image:: https://codecov.io/gh/eWaterCycle/era5cli/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/eWaterCycle/era5cli/branch/main/graph/badge.svg?token=qeZXgGASBK
    :target: https://codecov.io/gh/eWaterCycle/era5cli
    :alt: Test coverage
 

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ era5cli
    :target: https://github.com/eWaterCycle/era5cli/actions/workflows/test_codecov.yml
    :alt: Github Actions
 
-.. image:: https://codecov.io/gh/eWaterCycle/era5cli/branch/main/graph/badge.svg?token=qeZXgGASBK
+.. image:: https://codecov.io/gh/eWaterCycle/era5cli/branch/master/graph/badge.svg?token=qeZXgGASBK
    :target: https://codecov.io/gh/eWaterCycle/era5cli
    :alt: Test coverage
 


### PR DESCRIPTION
The badge showing CI status on README refers to the last time the action was run, not to the CI status on the master branch. Actions are only run on PR, so this makes sense. This PR should fix that and reflect CI status of the master branch.

Closes #103