### PR TITLE
update python version for readthedocs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ era5cli
     :alt: License
 
 .. image:: https://readthedocs.org/projects/era5cli/badge/?version=stable
-:target: https://era5cli.readthedocs.io/en/stable/?badge=stable
-:alt: Documentation Status
+    :target: https://era5cli.readthedocs.io/en/stable/?badge=stable
+    :alt: Documentation Status
 
 .. image:: https://img.shields.io/badge/docs-stable-brightgreen.svg
    :target: http://era5cli.readthedocs.io/en/stable/?badge=stable

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,10 @@ era5cli
     :target: https://opensource.org/licenses/Apache-2.0
     :alt: License
 
+.. image:: https://readthedocs.org/projects/era5cli/badge/?version=stable
+:target: https://era5cli.readthedocs.io/en/stable/?badge=stable
+:alt: Documentation Status
+
 .. image:: https://img.shields.io/badge/docs-stable-brightgreen.svg
    :target: http://era5cli.readthedocs.io/en/stable/?badge=stable
    :alt: Stable Documentation
@@ -32,7 +36,7 @@ era5cli
 
 .. image:: https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8B-yellow
    :target: https://fair-software.eu
-   
+
 .. inclusion-marker-start-do-not-remove
 
 A command line interface to download ERA5 data from the `Copernicus Climate Data Store <https://climate.copernicus.eu/>`_.

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,2 +1,2 @@
 python:
-        version: 3.7
+        version: 3.9

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,2 +1,2 @@
 python:
-        version: 3.9
+        version: 3.8

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -104,7 +104,7 @@ call_result = [
 def clean_ids(call):
     call = call.replace('\n', ' ')
     call = call.replace('--dryrun', '')
-    return(call)
+    return call
 
 
 ids = [clean_ids(item["call"]) for item in call_result]


### PR DESCRIPTION
Build of docs is failing on reathedocs. This PR updates the python version that is used, and adds a status badge.