### PR TITLE
Fix start years 

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -72,6 +72,11 @@
             "affiliation": "Netherlands eScience Center",
             "name": "Verhoeven, Stefan",
             "orcid": "0000-0002-5821-2060"
+        },
+        {
+            "affiliation": "Environment and Climate Change Canada",
+            "name": "Malinina, Elizaveta",
+            "orcid": "0000-0002-4102-2877"
         }
     ],
     "description": "A command line interface to download ERA5 data from the Climate Data Store.\n",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -77,9 +77,14 @@ authors:
     family-names: Verhoeven
     given-names: Stefan
     orcid: https://orcid.org/0000-0002-5821-2060
+  -
+    affiliation: "Environment and Climate Change Canada"
+    family-names: Malinina
+    given-names: Elizaveta
+    orcid: https://orcid.org/0000-0002-4102-2877
 
 cff-version: 1.2.0
-date-released: 2021-11-30
+date-released: 2022-10-04
 doi: 10.5281/zenodo.3252665
 keywords:
   - "ERA5"
@@ -87,4 +92,4 @@ license: Apache-2.0
 message: "If you use this software, please cite it using these metadata."
 repository-code: "https://github.com/ewatercycle/era5cli"
 title: era5cli
-version: 1.3.1
+version: 1.3.2

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -92,4 +92,4 @@ license: Apache-2.0
 message: "If you use this software, please cite it using these metadata."
 repository-code: "https://github.com/ewatercycle/era5cli"
 title: era5cli
-version: 1.3.2
+version: 1.3.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -84,7 +84,7 @@ authors:
     orcid: https://orcid.org/0000-0002-4102-2877
 
 cff-version: 1.2.0
-date-released: 2022-10-04
+date-released: 2021-11-30
 doi: 10.5281/zenodo.3252665
 keywords:
   - "ERA5"

--- a/era5cli/__version__.py
+++ b/era5cli/__version__.py
@@ -10,6 +10,6 @@ __author__ = ('Ronald van Haren', 'Jaro Camphuijsen', 'Yifat Dzigan',
               'Niels Drost', 'Fakhereh Alidoost', 'Bouwe Andela',
               'Jerom Aerts', 'Berend Weel', 'Rolf Hut', 'Klaus Zimmermann',
               'Peter Kalverla', 'Barbara Vreede', 'Aytaç Paçal', 'Stef Smeets',
-              'Stefan Verhoeven')
+              'Stefan Verhoeven', 'Elizaveta Malinina')
 __email__ = 'ewatercycle@esciencecenter.nl'
-__version__ = '1.3.1'
+__version__ = '1.3.2'

--- a/era5cli/__version__.py
+++ b/era5cli/__version__.py
@@ -12,4 +12,4 @@ __author__ = ('Ronald van Haren', 'Jaro Camphuijsen', 'Yifat Dzigan',
               'Peter Kalverla', 'Barbara Vreede', 'Aytaç Paçal', 'Stef Smeets',
               'Stefan Verhoeven')
 __email__ = 'ewatercycle@esciencecenter.nl'
-__version__ = '1.3.2'
+__version__ = '1.3.1'

--- a/era5cli/__version__.py
+++ b/era5cli/__version__.py
@@ -10,6 +10,6 @@ __author__ = ('Ronald van Haren', 'Jaro Camphuijsen', 'Yifat Dzigan',
               'Niels Drost', 'Fakhereh Alidoost', 'Bouwe Andela',
               'Jerom Aerts', 'Berend Weel', 'Rolf Hut', 'Klaus Zimmermann',
               'Peter Kalverla', 'Barbara Vreede', 'Aytaç Paçal', 'Stef Smeets',
-              'Stefan Verhoeven', 'Elizaveta Malinina')
+              'Stefan Verhoeven')
 __email__ = 'ewatercycle@esciencecenter.nl'
 __version__ = '1.3.2'

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -148,7 +148,8 @@ def _build_parser():
                              Whether to download the preliminary back extension
                              (1950-1978). Note that when `--prelimbe` is used,
                              `--startyear` and `--endyear` should be set
-                             between 1950 and 1978.
+                             between 1950 and 1978. Please, be aware that
+                             from 1959 ERA5 data is available.
                              `--prelimbe` is incompatible with `--land`.
 
                              ''')
@@ -159,7 +160,7 @@ def _build_parser():
         help=textwrap.dedent('''\
                              Whether to download data from the ERA5-Land
                              dataset. Note that the ERA5-Land dataset starts in
-                             1981.
+                             1950.
                              `--land` is incompatible with the use of
                              `--prelimbe` and `--ensemble`.
 
@@ -343,12 +344,12 @@ def _construct_year_list(args):
                 'year should be between 1950 and 1978'
             )
         elif args.land:
-            assert 1981 <= year <= datetime.now().year, (
-                'for ERA5-Land, year should be between 1981 and present'
+            assert 1950 <= year <= datetime.now().year, (
+                'for ERA5-Land, year should be between 1950 and present'
             )
         else:
-            assert 1979 <= year <= datetime.now().year, (
-                'year should be between 1979 and present'
+            assert 1959 <= year <= datetime.now().year, (
+                'year should be between 1959 and present'
             )
 
     assert endyear >= args.startyear, (

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -149,7 +149,7 @@ def _build_parser():
                              (1950-1978). Note that when `--prelimbe` is used,
                              `--startyear` and `--endyear` should be set
                              between 1950 and 1978. Please, be aware that
-                             from 1959 ERA5 data is available.
+                             ERA5 data is available from 1959.
                              `--prelimbe` is incompatible with `--land`.
 
                              ''')

--- a/era5cli/fetch.py
+++ b/era5cli/fetch.py
@@ -387,7 +387,8 @@ class Fetch:
         if self.prelimbe:
             if self.land:
                 raise ValueError(
-                    "Back extension not (yet) available for ERA5-Land.")
+                    "Back extension not available for ERA5-Land. "
+                    "ERA5-Land data is available from 1950 on.")
             name += "-preliminary-back-extension"
         return name, variable
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,14 +160,6 @@ def test_main_fetch(fetch):
     args = cli._parse_args(argv)
     cli._execute(args)
 
-    # no land available for back extension
-    argv = ['monthly', '--startyear', '1980', '--endyear', '1980',
-            '--variables', 'total_precipitation', '--synoptic',
-            '--ensemble', '--land']
-    args = cli._parse_args(argv)
-    with pytest.raises(AssertionError):
-        cli._execute(args)
-
 
 @mock.patch("era5cli.info.Info", autospec=True)
 def test_main_info(info):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -138,7 +138,7 @@ def test_main_fetch(fetch):
         assert cli._execute(args)
 
     # should give an AssertionError if years are out of bounds
-    argv = ['hourly', '--startyear', '1950',
+    argv = ['hourly', '--startyear', '1949',
             '--variables', 'total_precipitation', '--statistics',
             '--endyear', '2007', '--ensemble']
     args = cli._parse_args(argv)


### PR DESCRIPTION
Hi all, 

Here is a pull request to change the start years for ERA5 to 1959 and ERA5-Land to 1950 for both. I checked and they both work. The test, which returns assertation error for ERA5-Land being outside the bounds was removed. This pull request resolves issue #122.  

I was thinking of adding a warning, in case one wants to download a preliminary version from 1959 to 1978, but by the looks of it, era5cli doesn't use warnings package. Let me know if I should add the warning in some fashion, or just leave it as it is.

I also humbly added my name to the creators list, but if you think the contribution is too small, feel free to remove it. Please, let me know if anything else needs to be done. 

Cheers