### PR TITLE
Update documentation theme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,17 +4,9 @@ era5cli
     :target: https://opensource.org/licenses/Apache-2.0
     :alt: License
 
-.. image:: https://readthedocs.org/projects/era5cli/badge/?version=stable
-    :target: https://era5cli.readthedocs.io/en/stable/?badge=stable
+.. image:: https://readthedocs.org/projects/era5cli/badge/?version=latest
+    :target: https://era5cli.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
-
-.. image:: https://img.shields.io/badge/docs-stable-brightgreen.svg
-   :target: http://era5cli.readthedocs.io/en/stable/?badge=stable
-   :alt: Stable Documentation
-
-.. image:: https://img.shields.io/badge/docs-latest-brightgreen.svg
-   :target: http://era5cli.readthedocs.io/en/latest/?badge=latest
-   :alt: Latest Documentation
 
 .. image:: https://github.com/eWaterCycle/era5cli/actions/workflows/test_codecov.yml/badge.svg
    :target: https://github.com/eWaterCycle/era5cli/actions/workflows/test_codecov.yml

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ copyright = '2019, Netherlands eScience Center'
 author = 'era5cli team'
 
 # The full version, including alpha/beta/rc tags
-release = '1.0.0'
+release = '1.3.1'
 
 
 # -- General configuration ---------------------------------------------------
@@ -54,7 +54,7 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,7 +5,7 @@ Install from PyPI
 ~~~~~~~~~~~~~~~~~
 era5cli is available as a package in `PyPI <https://pypi.org/project/era5cli/>`_.
 
-To install from PyPI, the following command can be used:
+To install from PyPI, use the following command:
 ::
 
    pip install era5cli

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest-flake8
 pytest-cov
 Sphinx
 sphinx-argparse
+sphinx_rtd_theme


### PR DESCRIPTION
This PR updates the documentation theme; this way, we don't have to look at the ugly alabaster theme when we update the documentation 🙃

We have changed the settings on Readthedocs so it will automatically show a preview of documentation as part of a PR. Follow the link below (in the checks) or [see the updated docs here](https://era5cli--125.org.readthedocs.build/en/125/).

This was (eventually) found in Admin > Advanced settings > Build pull requests for this project.