### PR TITLE
Use hatch environments and scripts for styling, tests, docs & CI

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -27,4 +27,4 @@ jobs:
     - name: Check codestyle
       run: hatch run style:check
     - name: Build the package
-      run: python -m build
+      run: hatch build

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -20,18 +20,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
-    - name: Install dependencies and package
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .[dev]
+    - name: Update pip and hatch
+      run: python -m pip install --upgrade pip hatch
     - name: Test with pytest
-      run: pytest
+      run: hatch run test:check
     - name: Check codestyle
-      run: |
-        flake8
-        isort . --check
-        black . --check
-    - name: Install build dependencies and build package
-      run: |
-        python -m pip install build hatch --user
-        python -m build
+      run: hatch run style:check
+    - name: Build the package
+      run: python -m build

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -23,8 +23,8 @@ jobs:
     - name: Update pip and hatch
       run: python -m pip install --upgrade pip hatch
     - name: Test with pytest
-      run: hatch run test:check
+      run: hatch run test
     - name: Check codestyle
-      run: hatch run style:check
+      run: hatch run lint
     - name: Build the package
       run: hatch build

--- a/.github/workflows/test_codecov.yml
+++ b/.github/workflows/test_codecov.yml
@@ -17,12 +17,10 @@ jobs:
       with:
         python-version: "3.10"
         architecture: x64
-    - name: Install dependencies and package
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .[dev]
+    - name: Update pip and hatch
+      run: python -m pip install --upgrade pip hatch
     - name: Generate test coverage
-      run: pytest --cov=era5cli --cov-report term --cov-report xml:cov.xml tests/
+      run: hatch run test:cov
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/test_codecov.yml
+++ b/.github/workflows/test_codecov.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Update pip and hatch
       run: python -m pip install --upgrade pip hatch
     - name: Generate test coverage
-      run: hatch run test:cov
+      run: hatch run coverage
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -18,8 +18,8 @@ Contribute to the tool
 Create and activate the development environment:
 ::
 
-    python3 -m venv env
-    . env/bin/activate
+    python3 -m venv envname
+    . envname/bin/activate  # use './envname/Scripts/Activate.ps1' on windows.
 
 
 Populate the development environment with the required dependencies:
@@ -28,24 +28,18 @@ Populate the development environment with the required dependencies:
     pip install -U pip
     pip install -e .[dev]
 
-Before pushing a new addition, some tools are required to confirm that the code
+Before pushing a new addition, some checks are required to confirm that the code
 is up to standard.
 
-Use pytest to run the test suite:
+To run the test suite:
 ::
 
-   pytest
+   hatch run test:run
 
-Use flake8 to check for code style issues:
+To format the code, and check the code styling:
 ::
 
-   flake8 .
-
-And lastly, format the code and sort the imports using black and isort:
-::
-
-   black .
-   isort .
+   hatch run style:fmt
 
 Deactivate the environment with:
 ::
@@ -61,4 +55,4 @@ When updating the documentation, use the environment created above.
 Build the documentation with:
 ::
 
-   sphinx-build docs/source docs/build
+   hatch run docs:build

--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -34,7 +34,7 @@ is up to standard.
 To run the test suite:
 ::
 
-   hatch run test:run
+   hatch run test:check
 
 To format the code, and check the code styling:
 ::

--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -15,18 +15,18 @@ using and the version of the cdsapi library installed.
 Contribute to the tool
 ======================
 
+Make sure `pip` and `hatch` are up to date:
+::
+
+   python3 -m pip install pip hatch --upgrade
+
 Create and activate the development environment:
 ::
 
-    python3 -m venv envname
-    . envname/bin/activate  # use './envname/Scripts/Activate.ps1' on windows.
+   hatch shell  # Or: python3 -m hatch shell
 
-
-Populate the development environment with the required dependencies:
-::
-
-    pip install -U pip
-    pip install -e .[dev]
+This will start a virtual environment with the required dependencies to allow for
+development. Run this command before trying out any changes made to the code.
 
 Before pushing a new addition, some checks are required to confirm that the code
 is up to standard.
@@ -34,25 +34,23 @@ is up to standard.
 To run the test suite:
 ::
 
-   hatch run test:check
+   hatch run test
 
 To format the code, and check the code styling:
 ::
 
-   hatch run style:fmt
+   hatch run format
 
-Deactivate the environment with:
+Exit the the environment with:
 ::
 
-   deactivate
+   exit
 
 
 Contribute to the documentation
 ===============================
 
-When updating the documentation, use the environment created above.
-
-Build the documentation with:
+When updating the documentation, build the documentation with:
 ::
 
    hatch run docs:build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,51 +65,39 @@ dynamic = ["version"]
 era5cli="era5cli.cli:main"
 
 [project.optional-dependencies]
-dev = ["hatch",]
+dev = [
+  "hatch",
+  "flake8",
+  "flake8-pyproject",
+  "black",
+  "isort",
+  "pytest",
+  "pytest-flake8",
+  "pytest-cov",
+]
 docs = ["Sphinx", "sphinx-argparse", "sphinx_rtd_theme",]  # Required for readthedocs
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
-[tool.hatch.envs.style]
-detached = true
-dependencies = [
-  "flake8",
-  "flake8-pyproject",
-  "black",
-  "isort",
-]
+[tool.hatch.envs.default]
+features = ["dev",]
 
-[tool.hatch.envs.style.scripts]
-check = [
-  "flake8 .",
+[tool.hatch.envs.default.scripts]
+lint = [
+  "flake8p .",  # flake8p ensures pyproject.toml is used for configuration
   "black --check --diff .",
   "isort --check-only --diff .",
 ]
-fmt = ["isort .", "black .", "check",]
+format = ["isort .", "black .", "lint",]
+test = ["pytest",]
+coverage = ["pytest --cov=era5cli --cov-report term --cov-report xml:cov.xml tests/"]
 
 [tool.hatch.envs.docs]
-dependencies = [
-  "Sphinx",
-  "sphinx-argparse",
-  "sphinx_rtd_theme",
-]
+features = ["docs",]
 
 [tool.hatch.envs.docs.scripts]
 build = ["sphinx-build docs/source docs/build",]
-
-[tool.hatch.envs.test]
-dependencies = [
-  "flake8",
-  "flake8-pyproject",
-  "pytest",
-  "pytest-flake8",
-  "pytest-cov",
-]
-
-[tool.hatch.envs.test.scripts]
-check = ["pytest",]
-cov = ["pytest --cov=era5cli --cov-report term --cov-report xml:cov.xml tests/"]
 
 [tool.black]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,9 +65,8 @@ dynamic = ["version"]
 era5cli="era5cli.cli:main"
 
 [project.optional-dependencies]
-dev = [
-    "hatch",
-]
+dev = ["hatch",]
+docs = ["Sphinx", "sphinx-argparse", "sphinx_rtd_theme",]  # Required for readthedocs
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -109,7 +108,7 @@ dependencies = [
 ]
 
 [tool.hatch.envs.test.scripts]
-run = ["pytest",]
+check = ["pytest",]
 cov = ["pytest --cov=era5cli --cov-report term --cov-report xml:cov.xml tests/"]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,20 +66,51 @@ era5cli="era5cli.cli:main"
 
 [project.optional-dependencies]
 dev = [
-    "pytest",
-    "flake8",
-    "flake8-pyproject",
-    "pytest-flake8",
-    "pytest-cov",
-    "black",
-    "isort",
-    "Sphinx",
-    "sphinx-argparse",
-    "sphinx_rtd_theme"
+    "hatch",
 ]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.hatch.envs.style]
+detached = true
+dependencies = [
+  "flake8",
+  "flake8-pyproject",
+  "black",
+  "isort",
+]
+
+[tool.hatch.envs.style.scripts]
+check = [
+  "flake8 .",
+  "black --check --diff .",
+  "isort --check-only --diff .",
+]
+fmt = ["isort .", "black .", "check",]
+
+[tool.hatch.envs.docs]
+dependencies = [
+  "Sphinx",
+  "sphinx-argparse",
+  "sphinx_rtd_theme",
+]
+
+[tool.hatch.envs.docs.scripts]
+build = ["sphinx-build docs/source docs/build",]
+
+[tool.hatch.envs.test]
+dependencies = [
+  "flake8",
+  "flake8-pyproject",
+  "pytest",
+  "pytest-flake8",
+  "pytest-cov",
+]
+
+[tool.hatch.envs.test.scripts]
+run = ["pytest",]
+cov = ["pytest --cov=era5cli --cov-report term --cov-report xml:cov.xml tests/"]
 
 [tool.black]
 line-length = 88

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -10,4 +10,4 @@ python:
     - method: pip
       path: .
       extra_requirements:
-        - dev
+        - docs


### PR DESCRIPTION
Hatch scripts are set up for;

- Checking code style, and formatting the code
- Running the tests, running the tests+coverage (for codecov)
- Generating the docs

In Github Actions, the scripts now use these hatch commands as well.

contribute.rst has been updated with these new commands (making it a lot more succinct and easy for developers).

ReadTheDocs sadly still depends on the pip install, and we're not able to configure the build script there 👎 