### PR TITLE
Split ERA5-land/ensemble requests by month. Refactor cli.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Unreleased
 ~~~~~~~~~~
 * Change CDS keys from .cdsapirc file to .config/eracli.txt file. This will avoid conflict with e.g. ADS.
 * Add validator for era5cli.txt keys. This should provide better feedback to users and reduce user error.
+* Automatically split up requests for --land and --ensemble by month. This will prevent users encountering a Request Too Large error.
 
 1.3.2 (2021-12-13)
 ~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,8 @@ Unreleased
 * Change CDS keys from .cdsapirc file to .config/eracli.txt file. This will avoid conflict with e.g. ADS.
 * Add validator for era5cli.txt keys. This should provide better feedback to users and reduce user error.
 * Added --splitmonths argument for `era5cli hourly`. This allows users to avoid a Request Too Large error.
+* If a user makes a request without --splitmonths they are warned that the behavior will change in the future, and that they have to choose between --splitmonths False and --splitmonths True.
 * When a request would encounter a Request Too Large error in the CDS API, they are warned, and given a suggestion to use --splitmonths.
-* If a user makes a request for hourly --land or --ensemble without --splitmonths they are warned that the behavior will change in the future.
 * cli.py has been refactored to make the structure more clear. Seperate argument builders are now in their own modules.
 
 1.3.2 (2021-12-13)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,10 @@ Unreleased
 ~~~~~~~~~~
 * Change CDS keys from .cdsapirc file to .config/eracli.txt file. This will avoid conflict with e.g. ADS.
 * Add validator for era5cli.txt keys. This should provide better feedback to users and reduce user error.
-* Automatically split up requests for --land and --ensemble by month. This will prevent users encountering a Request Too Large error.
+* Added --splitmonths argument for `era5cli hourly`. This allows users to avoid a Request Too Large error.
+* When a request would encounter a Request Too Large error in the CDS API, they are warned, and given a suggestion to use --splitmonths.
+* If a user makes a request for hourly --land or --ensemble without --splitmonths they are warned that the behavior will change in the future.
+* cli.py has been refactored to make the structure more clear. Seperate argument builders are now in their own modules.
 
 1.3.2 (2021-12-13)
 ~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Release Notes
 *************
 
+Unreleased
+~~~~~~~~~~
+* Change CDS keys from .cdsapirc file to .config/eracli.txt file. This will avoid conflict with e.g. ADS.
+* Add validator for era5cli.txt keys. This should provide better feedback to users and reduce user error.
+
 1.3.2 (2021-12-13)
 ~~~~~~~~~~~~~~~~~~
 * Elaborate the range of years that can be queried `#123 <https://github.com/eWaterCycle/era5cli/pull/123>`_

--- a/docs/source/instructions.rst
+++ b/docs/source/instructions.rst
@@ -11,45 +11,19 @@ Register at Copernicus Climate Data Service
 
 -  Copy your user ID and API key.
 
-Create a key ascii file
-~~~~~~~~~~~~~~~~~~~~~~~
+Configure era5cli to use your ID and key
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Linux
-#####
-In Linux create a new file called .cdsapirc in the home directory of your user and add the following two lines:
-
+To configure era5cli to use your ID and API key, do:
 ::
 
-   url: https://cds.climate.copernicus.eu/api/v2
-
-   key: UID:KEY
-
-Replace UID with your user ID and KEY with your API key
-
-Windows
-#######
-In Windows create a new file called .cdsapirc (e.g. with Notepad) where in your windows environment, %USERPROFILE% is usually located at C:\Users\Username folder). And add the following two lines
-
-::
-
-   url: https://cds.climate.copernicus.eu/api/v2
-
-   key: UID:KEY
-
-Replace UID with your user ID and KEY with your API key
-
-MacOS
-#####
-In MacOS create a new file called .cdsapirc in the home directory of your user and add the following two lines:
+   era5cli config --uid ID_NUMBER --key "KEY"
 
 
-::
+Where ID_NUMBER is your user ID (e.g. ``123456``) and "KEY" is your API key, inside double quotes (e.g. ``"4s215sgs-2dfa-6h34-62h2-1615ad163414"``).
 
-   url: https://cds.climate.copernicus.eu/api/v2
+After running this command your ID and key are validated and stored inside your home folder, under ``.config/era5cli.txt``. You can also edit this file manually.
 
-   key: UID:KEY
-
-Replace UID with your user ID and KEY with your API key
 
 Info on available variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/era5cli/__version__.py
+++ b/era5cli/__version__.py
@@ -23,6 +23,7 @@ __author__ = (
     "Stef Smeets",
     "Stefan Verhoeven",
     "Elizaveta Malinina",
+    "Bart Schilperoort",
 )
 __email__ = "ewatercycle@esciencecenter.nl"
 __version__ = "1.3.2"

--- a/era5cli/_request_size.py
+++ b/era5cli/_request_size.py
@@ -42,6 +42,4 @@ def request_too_large(fetch: "Fetch") -> bool:
     if fetch.statistics:
         request_size *= 3  # Mean and spread are added.
 
-    if request_size > MAX_REQUESTS:
-        return True
-    return False
+    return True if request_size > MAX_REQUESTS else False

--- a/era5cli/_request_size.py
+++ b/era5cli/_request_size.py
@@ -8,6 +8,11 @@ if TYPE_CHECKING:
     from era5cli.fetch import Fetch
 
 
+# The following "MAX_REQUESTS" come from the cds.climate.copernicus.eu
+# api request generator. On the CDS one 'request' represents one 2D 'image' of the data
+# i.e. one variable, at one timestep, at one (pressure)level.
+# Single- and multi- level variables have a limit of 120.000 requests, while ERA5-land
+# is limited to 1000, likely due to the higher spatial resolution.
 MAX_REQUESTS = 120000  # Maximum requests for non-land data
 MAX_REQUESTS_LAND = 1000  # Max requests for "reanalysis-era5-land"
 VALID_HOURS_ENSEMBLE = [0, 3, 6, 9, 12, 15, 18, 21]

--- a/era5cli/_request_size.py
+++ b/era5cli/_request_size.py
@@ -1,0 +1,47 @@
+"""Module to compute the size of the CDS request."""
+
+from typing import TYPE_CHECKING
+from era5cli import inputref
+
+
+if TYPE_CHECKING:
+    from era5cli.fetch import Fetch
+
+
+MAX_REQUESTS = 120000  # Maximum requests for non-land data
+MAX_REQUESTS_LAND = 1000  # Max requests for "reanalysis-era5-land"
+VALID_HOURS_ENSEMBLE = [0, 3, 6, 9, 12, 15, 18, 21]
+
+
+class TooLargeRequestError(Exception):
+    """Raised when a request is too big for the CDS."""
+
+
+def n_hours(fetch: "Fetch") -> int:
+    """Get the number of hours in a request."""
+    if fetch.ensemble:
+        return sum(hr in fetch.hours for hr in VALID_HOURS_ENSEMBLE)
+    return len(fetch.hours)
+
+
+def request_too_large(fetch: "Fetch") -> bool:
+    """Determine if a request will raise a Too Large Request error at the CDS."""
+    n_months = 1 if fetch.splitmonths else len(fetch.months)
+
+    # Each time step counts as a request
+    request_size = n_months * len(fetch.days) * n_hours(fetch)
+
+    if fetch.land:
+        return True if request_size > MAX_REQUESTS_LAND else False
+
+    # Every pressure level is a separate request
+    if any([var in inputref.PLVARS for var in fetch.variables]):
+        request_size *= len(fetch.pressure_levels)
+
+    # Each (ensemble) statistic counts as a separate request
+    if fetch.statistics:
+        request_size *= 3  # Mean and spread are added.
+
+    if request_size > MAX_REQUESTS:
+        return True
+    return False

--- a/era5cli/args/__init__.py
+++ b/era5cli/args/__init__.py
@@ -1,0 +1,7 @@
+from . import common
+from . import config
+from . import info
+from . import periods
+
+
+__all__ = ["common", "config", "periods", "info"]

--- a/era5cli/args/__init__.py
+++ b/era5cli/args/__init__.py
@@ -1,7 +1,7 @@
-from . import common
-from . import config
-from . import info
-from . import periods
+from era5cli.args import common
+from era5cli.args import config
+from era5cli.args import info
+from era5cli.args import periods
 
 
 __all__ = ["common", "config", "periods", "info"]

--- a/era5cli/args/common.py
+++ b/era5cli/args/common.py
@@ -1,17 +1,16 @@
 import textwrap
 from argparse import ArgumentParser
+from datetime import datetime
 from typing import Union
 import era5cli.inputref as ref
 
 
 def _level_parse(level: str) -> Union[str, int]:
     """Parse levels as integers, or the string 'surface'"""
-    if level == "surface":
-        return str(level)
-    return int(level)
+    return level if level == "surface" else int(level)
 
 
-def populate_common(argument_parser: ArgumentParser) -> None:
+def add_common_args(argument_parser: ArgumentParser) -> None:
     """Populate the ArgumentParser with common (shared) arguments.
 
     Adds the following arguments:
@@ -242,3 +241,28 @@ def populate_common(argument_parser: ArgumentParser) -> None:
             """
         ),
     )
+
+
+def construct_year_list(args):
+    """Make a continous list of years from the startyear and endyear arguments."""
+    if not args.endyear:
+        endyear = args.startyear
+    else:
+        endyear = args.endyear
+
+    # check whether correct years have been entered
+    for year in (args.startyear, endyear):
+        if args.prelimbe:
+            assert 1950 <= year <= 1978, "year should be between 1950 and 1978"
+        elif args.land:
+            assert (
+                1950 <= year <= datetime.now().year
+            ), "for ERA5-Land, year should be between 1950 and present"
+        else:
+            assert (
+                1959 <= year <= datetime.now().year
+            ), "year should be between 1959 and present"
+
+    assert endyear >= args.startyear, "endyear should be >= startyear or None"
+
+    return list(range(args.startyear, endyear + 1))

--- a/era5cli/args/common.py
+++ b/era5cli/args/common.py
@@ -1,0 +1,243 @@
+import textwrap
+from argparse import ArgumentParser
+import era5cli.inputref as ref
+
+
+def _level_parse(level: str) -> int:
+    """Parse levels as integers, or the string 'surface'"""
+    if level == "surface":
+        return str(level)
+    return int(level)
+
+
+def populate_common(argument_parser: ArgumentParser) -> None:
+    """Populate the ArgumentParser with common (shared) arguments.
+
+    Adds the following arguments:
+        --variables,
+        --startyear,
+        --endyear,
+        --levels,
+        --outputprefix,
+        --format,
+        --merge,
+        --threads,
+        --ensemble,
+        --dryrun,
+        --prelimbe,
+        --land,
+        --area,
+
+    Args:
+        argument_parser: the ArgumentParser that the arguments are added to.
+    """
+    argument_parser.add_argument(
+        "--variables",
+        type=str,
+        required=True,
+        nargs="+",
+        help=textwrap.dedent(
+            """
+            The variables to download data for. This can be a
+            single variable, or multiple. See the Copernicus
+            Climate Data Store website or run
+            `era5cli info -h` for available variables.
+
+            """
+        ),
+    )
+
+    argument_parser.add_argument(
+        "--startyear",
+        type=int,
+        required=True,
+        help=textwrap.dedent(
+            """
+            Single year or first year of range for which
+            data should be downloaded.
+            Every year will be downloaded in a separate file
+            by default. Set `--split false` to change this
+
+            """
+        ),
+    )
+
+    argument_parser.add_argument(
+        "--endyear",
+        type=int,
+        required=False,
+        default=None,
+        help=textwrap.dedent(
+            """
+            Last year of range for which data should be
+            downloaded.
+            If only a single year is needed, only
+            `--startyear` needs to be specified.
+            Every year will be downloaded in a separate file
+            by default. Set `--split false` to change this
+
+            """
+        ),
+    )
+
+    argument_parser.add_argument(
+        "--levels",
+        nargs="+",
+        type=_level_parse,
+        required=False,
+        default=ref.PLEVELS,
+        help=textwrap.dedent(
+            """
+            Pressure level(s) to download 3D variables for.
+            Default is all available levels. See the Copernicus
+            Climate Data Store website or run `era5cli info -h`
+            for available pressure levels. For geopotential,
+            `--levels surface` can be used to request data from
+            the single level dataset (previously called
+            orography)
+
+            """
+        ),
+    )
+
+    argument_parser.add_argument(
+        "--outputprefix",
+        type=str,
+        default="era5",
+        help=textwrap.dedent(
+            """
+            Prefix to be used for the output filename.
+            Default prefix is `era5`
+
+            """
+        ),
+    )
+
+    argument_parser.add_argument(
+        "--format",
+        type=str,
+        default="netcdf",
+        choices=["netcdf", "grib"],
+        help=textwrap.dedent(
+            """
+            Output file type. Defaults to `netcdf`
+
+            """
+        ),
+    )
+
+    argument_parser.add_argument(
+        "--merge",
+        action="store_true",
+        default=False,
+        help=textwrap.dedent(
+            """
+            Merge yearly output files.
+            Default is split output files into separate files
+            for every year
+
+            """
+        ),
+    )
+
+    argument_parser.add_argument(
+        "--threads",
+        type=int,
+        choices=range(1, 7),
+        required=False,
+        default=None,
+        help=textwrap.dedent(
+            """
+            Number of parallel threads to use when
+            downloading. Defaults to a single process
+
+            """
+        ),
+    )
+
+    argument_parser.add_argument(
+        "--ensemble",
+        action="store_true",
+        default=False,
+        help=textwrap.dedent(
+            """
+            Whether to download high resolution realisation
+            (HRES) or a reduced resolution ten member ensemble
+            (EDA). Providing the `--ensemble` argument
+            downloads the reduced resolution ensemble.
+            `--ensemble` is incompatible with `--land`
+
+            """
+        ),
+    )
+
+    argument_parser.add_argument(
+        "--dryrun",
+        action="store_true",
+        default=False,
+        help=textwrap.dedent(
+            """
+            Whether to print the cdsapi request to the screen,
+            or make the request to start downloading the data.
+            Providing the `--dryrun` argument will print the
+            request to stdout. By default, the data will be
+            downloaded
+
+            """
+        ),
+    )
+
+    argument_parser.add_argument(
+        "--prelimbe",
+        action="store_true",
+        default=False,
+        help=textwrap.dedent(
+            """
+            Whether to download the preliminary back extension
+            (1950-1978). Note that when `--prelimbe` is used,
+            `--startyear` and `--endyear` should be set
+            between 1950 and 1978. Please, be aware that
+            ERA5 data is available from 1959.
+            `--prelimbe` is incompatible with `--land`
+
+            """
+        ),
+    )
+
+    argument_parser.add_argument(
+        "--land",
+        action="store_true",
+        default=False,
+        help=textwrap.dedent(
+            """
+            Whether to download data from the ERA5-Land
+            dataset. Note that the ERA5-Land dataset starts in
+            1950.
+            `--land` is incompatible with the use of
+            `--prelimbe` and `--ensemble`
+
+            """
+        ),
+    )
+
+    argument_parser.add_argument(
+        "--area",
+        nargs=4,
+        type=float,
+        metavar=("LAT_MAX", "LON_MIN", "LAT_MIN", "LON_MAX"),
+        required=False,
+        help=textwrap.dedent(
+            """
+            Coordinates in case extraction of a subregion is
+            requested.
+            Specified as `LAT_MAX LON_MIN LAT_MIN LON_MAX`
+            (counterclockwise coordinates, starting at the top)
+            with longitude in the range -180, +180
+            and latitude in the range -90, +90. For example:
+            `--area 90 -180 -90 180`. Requests are rounded down
+            to two decimals. By default, the entire
+            available area will be returned
+
+            """
+        ),
+    )

--- a/era5cli/args/common.py
+++ b/era5cli/args/common.py
@@ -1,7 +1,7 @@
 import textwrap
 from argparse import ArgumentParser
-import era5cli.inputref as ref
 from typing import Union
+import era5cli.inputref as ref
 
 
 def _level_parse(level: str) -> Union[str, int]:

--- a/era5cli/args/common.py
+++ b/era5cli/args/common.py
@@ -1,9 +1,10 @@
 import textwrap
 from argparse import ArgumentParser
 import era5cli.inputref as ref
+from typing import Union
 
 
-def _level_parse(level: str) -> int:
+def _level_parse(level: str) -> Union[str, int]:
     """Parse levels as integers, or the string 'surface'"""
     if level == "surface":
         return str(level)

--- a/era5cli/args/config.py
+++ b/era5cli/args/config.py
@@ -1,0 +1,123 @@
+import argparse
+import textwrap
+from era5cli import key_management
+
+
+def add_config_args(subparsers: argparse._SubParsersAction) -> None:
+    """Populate the subparsers with the 'config' parser.
+
+    The config parser allows users to view as well as set their cds API keys.
+
+    Adds the 'config' parser with the following arguments:
+        --show
+        --uid
+        --key
+        --url
+
+    Args:
+        subparsers: Subparsers to which the 'config' parser should be added to.
+    """
+    config = subparsers.add_parser(
+        "config",
+        description="",
+        prog=textwrap.dedent(
+            """
+            Configure the CDS login info for era5cli.
+
+            This will create a config file in your home directory, in folder named
+            ".config". The CDS URL, your UID and the CDS keys will be stored here.
+
+            To find your key and UID, go to https://cds.climate.copernicus.eu/ and
+            login with your email and password. Then go to your user profile (top
+            right).
+
+            Use `era5cli config --help` for more information.
+            """
+        ),
+        help=textwrap.dedent(
+            """
+            Configure the CDS login info for era5cli.
+
+            """
+        ),
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+
+    config.add_argument(
+        "--show",
+        action="store_true",
+        default=False,
+        help=textwrap.dedent(
+            """
+            Print the stored keys to the screen.
+            """
+        ),
+    )
+
+    config.add_argument(
+        "--uid",
+        type=str,
+        help=textwrap.dedent(
+            """
+            Your CDS User ID, e.g.: 123456
+            """
+        ),
+    )
+
+    config.add_argument(
+        "--key",
+        type=str,
+        help=textwrap.dedent(
+            """
+            Your CDS key, e.g.: "4s215sgs-2dfa-6h34-62h2-1615ad163414"
+            """
+        ),
+    )
+
+    config.add_argument(
+        "--url",
+        type=str,
+        required=False,
+        default=key_management.DEFAULT_CDS_URL,
+        help=textwrap.dedent(
+            f"""
+            (optional) URL to the CDS, by default:
+                {key_management.DEFAULT_CDS_URL}
+            """
+        ),
+    )
+
+
+def config_control_flow(args):
+    """Control flow for the config subparser.
+
+    This custom control flow is required to implement the exclusive
+    groups [show] and [uid + key (+ url)], and specifies the behavior
+    of these arguments.
+
+    Args:
+        args: Arguments collected by argparse
+
+    Returns:
+        True
+    """
+    if args.show and any((args.uid, args.key)):
+        raise AttributeError("Either call `show` or set the key. Not both.")
+    if not args.show and (args.uid is None or args.key is None):
+        raise AttributeError("Both the UID and the key are required inputs.")
+    if args.show:
+        url, fullkey = key_management.load_era5cli_config()
+        uid, key = fullkey.split(":")
+        print(
+            "Contents of .config/era5cli.txt:\n"
+            f"    uid: {uid}\n"
+            f"    key: {key}\n"
+            f"    url: {url}\n"
+        )
+        return True
+
+    return key_management.set_config(
+        url=args.url,
+        uid=args.uid,
+        key=args.key,
+    )

--- a/era5cli/args/config.py
+++ b/era5cli/args/config.py
@@ -88,6 +88,10 @@ def add_config_args(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
+class InputError(Exception):
+    "Raised when a user inputs an invalid combination of arguments."
+
+
 def config_control_flow(args):
     """Control flow for the config subparser.
 
@@ -102,9 +106,9 @@ def config_control_flow(args):
         True
     """
     if args.show and any((args.uid, args.key)):
-        raise AttributeError("Either call `show` or set the key. Not both.")
+        raise InputError("Either call `show` or set the key. Not both.")
     if not args.show and (args.uid is None or args.key is None):
-        raise AttributeError("Both the UID and the key are required inputs.")
+        raise InputError("Both the UID and the key are required inputs.")
     if args.show:
         url, fullkey = key_management.load_era5cli_config()
         uid, key = fullkey.split(":")

--- a/era5cli/args/config.py
+++ b/era5cli/args/config.py
@@ -92,7 +92,7 @@ class InputError(Exception):
     "Raised when a user inputs an invalid combination of arguments."
 
 
-def config_control_flow(args):
+def run_config(args):
     """Control flow for the config subparser.
 
     This custom control flow is required to implement the exclusive

--- a/era5cli/args/info.py
+++ b/era5cli/args/info.py
@@ -1,5 +1,6 @@
 import argparse
 import textwrap
+import era5cli.info
 
 
 def add_info_args(subparsers):
@@ -45,3 +46,13 @@ def add_info_args(subparsers):
             """
         ),
     )
+
+
+def run_info(args):
+    # List dataset information
+    era5info = era5cli.info.Info(args.name)
+    if era5info.infotype == "list":
+        era5info.list()
+        return True
+    era5info.vars()
+    return True

--- a/era5cli/args/info.py
+++ b/era5cli/args/info.py
@@ -49,6 +49,7 @@ def add_info_args(subparsers):
 
 
 def run_info(args):
+    """Run the info routine"""
     # List dataset information
     era5info = era5cli.info.Info(args.name)
     if era5info.infotype == "list":

--- a/era5cli/args/info.py
+++ b/era5cli/args/info.py
@@ -1,0 +1,47 @@
+import argparse
+import textwrap
+
+
+def add_info_args(subparsers):
+    """Add info parser and arguments.
+
+    Adds the 'info' parser, with the 'name' argument.
+    """
+    info = subparsers.add_parser(
+        "info",
+        description="Show information on available variables and levels.",
+        prog=textwrap.dedent(
+            """
+            Use `era5cli info --help` for more information
+
+            """
+        ),
+        help=textwrap.dedent(
+            """
+            Show information on available variables or levels.
+            Use `era5cli info --help` for more information
+
+            """
+        ),
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+
+    info.add_argument(
+        "name",
+        type=str,
+        help=textwrap.dedent(
+            """
+            Enter list name to print info list: \n
+            `levels` for all available pressure levels \n
+            `2Dvars` for all available single level or 2D
+            variables \n
+            `3Dvars` for all available 3D variables \n
+            `land` for all available variables in
+            ERA5-land \n
+            Enter variable name (e.g. `total_precipitation`)
+            or pressure level (e.g. `825`) to show if the
+            variable or level is available, and in which list
+
+            """
+        ),
+    )

--- a/era5cli/args/periods.py
+++ b/era5cli/args/periods.py
@@ -1,0 +1,138 @@
+import argparse
+import textwrap
+
+
+def add_period_args(subparsers, common):
+    """Add period related parsers and arguments.
+
+    Adds the following parsers:
+        monthly, daily, houry.
+
+    As well as the following arguments (for
+    some of the previously mentioned parsers):
+        --months, --days, --hours, --synoptic, --statistics
+    """
+    mnth = argparse.ArgumentParser(add_help=False)
+
+    mnth.add_argument(
+        "--months",
+        nargs="+",
+        required=False,
+        type=int,
+        default=list(range(1, 13)),
+        help=textwrap.dedent(
+            """
+            Month(s) to download data for. Defaults to all
+            months. For every year, only these
+            months will be downloaded
+
+            """
+        ),
+    )
+
+    day = argparse.ArgumentParser(add_help=False)
+
+    day.add_argument(
+        "--days",
+        nargs="+",
+        required=False,
+        type=int,
+        default=list(range(1, 32)),
+        help=textwrap.dedent(
+            """
+            Day(s) to download data for. Defaults to all days.
+            For every year, only these days will
+            be downloaded
+
+            """
+        ),
+    )
+
+    hour = argparse.ArgumentParser(add_help=False)
+
+    hour.add_argument(
+        "--hours",
+        nargs="+",
+        required=False,
+        type=int,
+        default=list(range(24)),
+        help=textwrap.dedent(
+            """
+            Time of day in hours to download data for.
+            Defaults to all hours. For every year,
+            only these hours will be downloaded
+
+            """
+        ),
+    )
+
+    hourly = subparsers.add_parser(
+        "hourly",
+        parents=[common, mnth, day, hour],
+        description="Execute the data fetch process for hourly data.",
+        prog=textwrap.dedent(
+            """
+            Use `era5cli hourly --help` for more information
+
+            """
+        ),
+        help=textwrap.dedent(
+            """
+            Execute the data fetch process for hourly data.
+            Use `era5cli hourly --help` for more information
+
+            """
+        ),
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+
+    hourly.add_argument(
+        "--statistics",
+        action="store_true",
+        help=textwrap.dedent(
+            """
+            When downloading hourly ensemble data, provide
+            the `--statistics` argument to download statistics
+            (ensemble mean and ensemble spread)
+
+            """
+        ),
+    )
+
+    monthly = subparsers.add_parser(
+        "monthly",
+        parents=[common, mnth],
+        description="Execute the data fetch process for monthly data.",
+        prog=textwrap.dedent(
+            """
+            Use `era5cli monthly --help` for more information
+
+            """
+        ),
+        help=textwrap.dedent(
+            """
+            Execute the data fetch process for monthly data.
+            Use `era5cli monthly --help` for more information
+
+            """
+        ),
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+
+    monthly.add_argument(
+        "--synoptic",
+        type=int,
+        default=False,
+        nargs="*",
+        help=textwrap.dedent(
+            """
+            Time of day in hours to get the synoptic means
+            (monthly averaged by hour of day) for. For example
+            `--synoptic 0 4 5 6 23`. Give empty option
+            `--synoptic` to download all hours (0-23).
+            The option defaults to `None` in which case the
+            monthly average of daily means is chosen
+
+            """
+        ),
+    )

--- a/era5cli/args/periods.py
+++ b/era5cli/args/periods.py
@@ -136,3 +136,32 @@ def add_period_args(subparsers, common):
             """
         ),
     )
+
+
+def set_period_args(args):
+    """Set subroutine specific arguments for monthly and hourly fetches."""
+    if args.command == "monthly":
+        statistics = None
+        days = None
+        if args.synoptic is False:
+            synoptic = None
+            hours = [0]
+        elif len(args.synoptic) == 0:
+            synoptic = True
+            hours = range(24)
+        else:
+            synoptic = True
+            hours = args.synoptic
+    elif args.command == "hourly":
+        synoptic = None
+        statistics = args.statistics
+        if statistics:
+            assert args.ensemble, (
+                "Statistics can only be computed over an ensemble, "
+                "add --ensemble or remove --statistics."
+            )
+        days = args.days
+        hours = args.hours
+    else:
+        raise AttributeError(f'The command "{args.command}" is not valid.')
+    return synoptic, statistics, days, hours

--- a/era5cli/args/periods.py
+++ b/era5cli/args/periods.py
@@ -6,7 +6,7 @@ def add_period_args(subparsers, common):
     """Add period related parsers and arguments.
 
     Adds the following parsers:
-        monthly, daily, houry.
+        monthly, hourly.
 
     As well as the following arguments (for
     some of the previously mentioned parsers):
@@ -99,6 +99,19 @@ def add_period_args(subparsers, common):
         ),
     )
 
+    hourly.add_argument(
+        "--splitmonths",
+        action="store_true",
+        help=textwrap.dedent(
+            """
+            When downloading hourly data, provide
+            the `--splitmonths` argument to split requests and files
+            by month, and add the month to the filename.
+
+            """
+        ),
+    )
+
     monthly = subparsers.add_parser(
         "monthly",
         parents=[common, mnth],
@@ -143,6 +156,7 @@ def set_period_args(args):
     if args.command == "monthly":
         statistics = None
         days = None
+        splitmonths = False
         if args.synoptic is False:
             synoptic = None
             hours = [0]
@@ -154,7 +168,8 @@ def set_period_args(args):
             hours = args.synoptic
     elif args.command == "hourly":
         synoptic = None
-        statistics = args.statistics
+        splitmonths: bool = args.splitmonths
+        statistics: bool = args.statistics
         if statistics:
             assert args.ensemble, (
                 "Statistics can only be computed over an ensemble, "
@@ -164,4 +179,4 @@ def set_period_args(args):
         hours = args.hours
     else:
         raise AttributeError(f'The command "{args.command}" is not valid.')
-    return synoptic, statistics, days, hours
+    return synoptic, statistics, splitmonths, days, hours

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -406,14 +406,18 @@ def _build_parser():
 
     config = subparsers.add_parser(
         "config",
-        description="Configure the CDS login info for era5cli",
+        description="",
         prog=textwrap.dedent(
             """
-            Use `era5cli config --help` for more information
+            Configure the CDS login info for era5cli.
+
+            This will create a config file in your home directory, in folder named
+            ".config". The CDS URL, your UID and the CDS keys will be stored here.
 
             To find your key and UID, go to https://cds.climate.copernicus.eu/ and login
             with your email and password. Then go to your user profile (top right).
 
+            Use `era5cli config --help` for more information.
             """
         ),
         help=textwrap.dedent(
@@ -454,7 +458,7 @@ def _build_parser():
         default=key_management.DEFAULT_CDS_URL,
         help=textwrap.dedent(
             f"""
-            URL to the CDS, by default: {key_management.DEFAULT_CDS_URL}
+            (optional) URL to the CDS, by default: {key_management.DEFAULT_CDS_URL}
             """
         ),
     )

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -82,7 +82,7 @@ def main(argv=None):
     using sys.argv.
     """
     if argv is None:
-        argv = sys.argv
+        argv = sys.argv  # pragma: no cover
 
     # Skip the first argument (i.e. 'era5cli')
     args = _parse_args(argv[1:])

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -145,4 +145,4 @@ def main(argv=None):
 
 
 if __name__ == "__main__":
-    main()
+    main()  # pragma: no cover

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -5,8 +5,6 @@ import argparse
 import sys
 import textwrap
 from datetime import datetime
-import certifi
-import urllib3
 import era5cli.fetch as efetch
 import era5cli.info as einfo
 import era5cli.inputref as ref
@@ -549,8 +547,6 @@ def _execute(args):
             uid=args.uid,
             key=args.key,
         )
-
-    _ = urllib3.PoolManager(cert_reqs="CERT_REQUIRED", ca_certs=certifi.where())
 
     # the fetching subroutines
     years = _construct_year_list(args)

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -45,7 +45,9 @@ def _execute(input_args: argparse.Namespace) -> True:
 
     # the fetching subroutines
     years = args.common.construct_year_list(input_args)
-    synoptic, statistics, days, hours = args.periods.set_period_args(input_args)
+    synoptic, statistics, splitmonths, days, hours = args.periods.set_period_args(
+        input_args
+    )
 
     # try to build and send download request
     era5 = efetch.Fetch(
@@ -63,6 +65,7 @@ def _execute(input_args: argparse.Namespace) -> True:
         statistics=statistics,
         pressurelevels=input_args.levels,
         threads=input_args.threads,
+        splitmonths=splitmonths,
         merge=input_args.merge,
         prelimbe=input_args.prelimbe,
         land=input_args.land,

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -5,12 +5,12 @@ import argparse
 import sys
 import textwrap
 from datetime import datetime
+import certifi
+import urllib3
 import era5cli.fetch as efetch
 import era5cli.info as einfo
 import era5cli.inputref as ref
 from era5cli import key_management
-import certifi
-import urllib3
 
 
 def _level_parse(level):

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -9,6 +9,8 @@ import era5cli.fetch as efetch
 import era5cli.info as einfo
 import era5cli.inputref as ref
 from era5cli import key_management
+import certifi
+import urllib3
 
 
 def _level_parse(level):
@@ -547,6 +549,8 @@ def _execute(args):
             uid=args.uid,
             key=args.key,
         )
+
+    _ = urllib3.PoolManager(cert_reqs="CERT_REQUIRED", ca_certs=certifi.where())
 
     # the fetching subroutines
     years = _construct_year_list(args)

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -8,6 +8,7 @@ from datetime import datetime
 import era5cli.fetch as efetch
 import era5cli.info as einfo
 import era5cli.inputref as ref
+from era5cli import key_management
 
 
 def _level_parse(level):
@@ -403,6 +404,61 @@ def _build_parser():
         ),
     )
 
+    config = subparsers.add_parser(
+        "config",
+        description="Configure the CDS login info for era5cli",
+        prog=textwrap.dedent(
+            """
+            Use `era5cli config --help` for more information
+
+            To find your key and UID, go to https://cds.climate.copernicus.eu/ and login
+            with your email and password. Then go to your user profile (top right).
+
+            """
+        ),
+        help=textwrap.dedent(
+            """
+            Configure the CDS login info for era5cli.
+
+            """
+        ),
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+
+    config.add_argument(
+        "--uid",
+        type=str,
+        required=True,
+        help=textwrap.dedent(
+            """
+            Your CDS User ID, e.g.: 123456
+            """
+        ),
+    )
+
+    config.add_argument(
+        "--key",
+        type=str,
+        required=True,
+        help=textwrap.dedent(
+            """
+            Your CDS key, e.g.: "4s215sgs-2dfa-6h34-62h2-1615ad163414"
+            """
+        ),
+    )
+
+    config.add_argument(
+        "--url",
+        type=str,
+        required=False,
+        default=key_management.DEFAULT_CDS_URL,
+        help=textwrap.dedent(
+            f"""
+            URL to the CDS, by default: {key_management.DEFAULT_CDS_URL}
+            """
+        ),
+    )
+
     return parser
 
 
@@ -480,6 +536,13 @@ def _execute(args):
     # the info subroutine
     if args.command == "info":
         return _run_info(args)
+
+    if args.command == "config":
+        return key_management.run_config(
+            url=args.url,
+            uid=args.uid,
+            key=args.key,
+        )
 
     # the fetching subroutines
     years = _construct_year_list(args)

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -3,9 +3,7 @@
 
 import argparse
 import sys
-from datetime import datetime
 import era5cli.fetch as efetch
-import era5cli.info as einfo
 from era5cli import args
 
 
@@ -19,7 +17,7 @@ def _build_parser():
     subparsers.required = True
 
     common = argparse.ArgumentParser(add_help=False)
-    args.common.populate_common(common)
+    args.common.add_common_args(common)
 
     args.periods.add_period_args(subparsers, common)
 
@@ -36,81 +34,19 @@ def _parse_args(args):
     return parser.parse_args(args)
 
 
-def _run_info(args):
-    # List dataset information
-    era5info = einfo.Info(args.name)
-    if era5info.infotype == "list":
-        era5info.list()
-        return True
-    era5info.vars()
-    return True
-
-
-def _construct_year_list(args):
-    if not args.endyear:
-        endyear = args.startyear
-    else:
-        endyear = args.endyear
-
-    # check whether correct years have been entered
-    for year in (args.startyear, endyear):
-        if args.prelimbe:
-            assert 1950 <= year <= 1978, "year should be between 1950 and 1978"
-        elif args.land:
-            assert (
-                1950 <= year <= datetime.now().year
-            ), "for ERA5-Land, year should be between 1950 and present"
-        else:
-            assert (
-                1959 <= year <= datetime.now().year
-            ), "year should be between 1959 and present"
-
-    assert endyear >= args.startyear, "endyear should be >= startyear or None"
-
-    return list(range(args.startyear, endyear + 1))
-
-
-def _set_period_args(args):
-    # set subroutine specific arguments for monthly and hourly fetch
-    if args.command == "monthly":
-        statistics = None
-        days = None
-        if args.synoptic is False:
-            synoptic = None
-            hours = [0]
-        elif len(args.synoptic) == 0:
-            synoptic = True
-            hours = range(24)
-        else:
-            synoptic = True
-            hours = args.synoptic
-    elif args.command == "hourly":
-        synoptic = None
-        statistics = args.statistics
-        if statistics:
-            assert args.ensemble, (
-                "Statistics can only be computed over an ensemble, "
-                "add --ensemble or remove --statistics."
-            )
-        days = args.days
-        hours = args.hours
-    else:
-        raise AttributeError(f'The command "{args.command}" is not valid.')
-    return synoptic, statistics, days, hours
-
-
 def _execute(input_args: argparse.Namespace) -> True:
     """Call to ERA-5 cli library."""
-    # the info subroutine
+
     if input_args.command == "info":
-        return _run_info(input_args)
+        return args.info.run_info(input_args)
 
     if input_args.command == "config":
         return args.config.config_control_flow(input_args)
 
     # the fetching subroutines
-    years = _construct_year_list(input_args)
-    synoptic, statistics, days, hours = _set_period_args(input_args)
+    years = args.common.construct_year_list(input_args)
+    synoptic, statistics, days, hours = args.periods.set_period_args(input_args)
+
     # try to build and send download request
     era5 = efetch.Fetch(
         years,

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -35,13 +35,13 @@ def _parse_args(args):
 
 
 def _execute(input_args: argparse.Namespace) -> True:
-    """Call to ERA-5 cli library."""
+    """Execute the arguments given by the user."""
 
     if input_args.command == "info":
         return args.info.run_info(input_args)
 
     if input_args.command == "config":
-        return args.config.config_control_flow(input_args)
+        return args.config.run_config(input_args)
 
     # the fetching subroutines
     years = args.common.construct_year_list(input_args)
@@ -72,10 +72,16 @@ def _execute(input_args: argparse.Namespace) -> True:
 
 
 def main(argv=None):
-    """Main."""
-    # get arguments
+    """Run era5cli.
+
+    argv is an optional kwarg to be used in testing. When called
+    from the command line, the user-input arguments are retreived
+    using sys.argv.
+    """
     if argv is None:
         argv = sys.argv
+
+    # Skip the first argument (i.e. 'era5cli')
     args = _parse_args(argv[1:])
     _execute(args)
 

--- a/era5cli/fetch.py
+++ b/era5cli/fetch.py
@@ -447,11 +447,10 @@ class Fetch:
         request = {
             "variable": variable,
             "year": years,
+            "month": self.months if months is None else months,
             "time": self.hours,
             "format": self.outputformat,
         }
-
-        request["month"] = self.months if months is None else months
 
         if "pressure-levels" in name:
             self._check_levels()

--- a/era5cli/fetch.py
+++ b/era5cli/fetch.py
@@ -221,7 +221,7 @@ class Fetch:
 
         fname = f"{prefix}_{var}_{yearblock}"
         if month is not None:
-            fname += f"_{month}"
+            fname += f"-{month}"
         fname += f"_{self.period}"
 
         if self.area:

--- a/era5cli/fetch.py
+++ b/era5cli/fetch.py
@@ -6,6 +6,7 @@ import cdsapi
 from pathos.threading import ThreadPool as Pool
 import era5cli.inputref as ref
 import era5cli.utils
+from era5cli import key_management
 
 
 class Fetch:
@@ -105,6 +106,8 @@ class Fetch:
         land=False,
     ):
         """Initialization of Fetch class."""
+        self._get_login()  # Get login info from config file.
+
         self.months = era5cli.utils._zpad_months(months)
         """list(str): List of zero-padded strings of months
         (e.g. ['01', '02',..., '12'])."""
@@ -157,6 +160,9 @@ class Fetch:
         self.land = land
         """bool: Whether to download from the ERA5-Land
         dataset."""
+
+    def _get_login(self):
+        self.url, self.key = key_management.load_era5cli_config()
 
     def fetch(self, dryrun=False):
         """Split calls and fetch results.
@@ -447,7 +453,7 @@ class Fetch:
                 "please do not kill this process in the meantime.",
                 os.linesep,
             )
-            connection = cdsapi.Client()
+            connection = cdsapi.Client(url=self.url, key=self.key)
             print("".join(queueing_message))  # print queueing message
             connection.retrieve(name, request, outputfile)
             era5cli.utils.append_history(name, request, outputfile)

--- a/era5cli/fetch.py
+++ b/era5cli/fetch.py
@@ -482,7 +482,7 @@ class Fetch:
                 "please do not kill this process in the meantime.",
                 os.linesep,
             )
-            connection = cdsapi.Client(url=self.url, key=self.key)
+            connection = cdsapi.Client(url=self.url, key=self.key, verify=True)
             print("".join(queueing_message))  # print queueing message
             connection.retrieve(name, request, outputfile)
             era5cli.utils.append_history(name, request, outputfile)

--- a/era5cli/fetch.py
+++ b/era5cli/fetch.py
@@ -173,13 +173,6 @@ class Fetch:
                 "\neach other. Please pick one of the two."
             )
 
-        if not splitmonths and self.period == "hourly" and (land or ensemble):
-            logging.warning(
-                "\n  The flag --splitmonths was not used, however, in a future version"
-                "\n  this flag will represent the default behavior for hourly --land"
-                "\n  and --ensemble requests. Please update your workflow accordingly."
-            )
-
         vars = list(self.variables)  # Use list() to avoid copying by reference
         if "geopotential" in vars and pressurelevels == ["surface"]:
             vars.remove("geopotential")
@@ -189,10 +182,10 @@ class Fetch:
 
         if self.period == "hourly" and request_too_large(self):
             raise TooLargeRequestError(
-                "\nYour request is too large for the CDS API."
-                "\nConsider splitting up your request in months, "
-                "using the '--splitmonths' flag."
-                "\nFor more info see 'era5cli hourly --help'."
+                "\n  Your request is too large for the CDS API."
+                "\n  Consider splitting up your request in months, "
+                "\n  by using '--splitmonths True'."
+                "\n  For more info see 'era5cli hourly --help'."
             )
 
     def _get_login(self):

--- a/era5cli/fetch.py
+++ b/era5cli/fetch.py
@@ -1,5 +1,6 @@
 """Fetch ERA5 variables."""
 
+import itertools
 import logging
 import os
 import cdsapi
@@ -7,7 +8,6 @@ from pathos.threading import ThreadPool as Pool
 import era5cli.inputref as ref
 import era5cli.utils
 from era5cli import key_management
-import itertools
 
 
 class Fetch:
@@ -266,9 +266,7 @@ class Fetch:
         months = []
 
         for var, year, month in itertools.product(
-            self.variables,
-            self.years,
-            self.months
+            self.variables, self.years, self.months
         ):
             outputfiles += [self._define_outputfilename(var, [year, year], month)]
             variables += [var]
@@ -277,7 +275,6 @@ class Fetch:
 
         pool = Pool(nodes=self.threads) if self.threads else Pool()
         pool.map(self._getdata, variables, years, outputfiles, months)
-
 
     def _product_type(self):
         """Construct the product type name from the options."""

--- a/era5cli/key_management.py
+++ b/era5cli/key_management.py
@@ -95,6 +95,9 @@ def run_config(
     try:
         attempt_cds_login(url, fullkey=f"{uid}:{key}")
         write_era5cli_config(url, uid, key)
+        print(
+            f"Keys succesfully validated and stored in {ERA5CLI_CONFIG_PATH.resolve()}"
+        )
         return True
     except InvalidLoginError:
         print(

--- a/era5cli/key_management.py
+++ b/era5cli/key_management.py
@@ -41,7 +41,7 @@ def attempt_cds_login(url: str, fullkey: str) -> True:
         url=url,
         key=fullkey,
         verify=True,
-        quiet=True,  # Supress output to the consolve from the test retrieve.
+        quiet=True,  # Supress output to the console from the test retrieve.
     )
 
     try:
@@ -83,7 +83,7 @@ def attempt_cds_login(url: str, fullkey: str) -> True:
                 f"{os.linesep}Something changed in the CDS API. Please raise an issue "
                 "on https://www.github.com/eWaterCycle/era5cli"
             ) from err
-        raise err
+        raise err  # pragma: no cover
 
 
 def run_config(

--- a/era5cli/key_management.py
+++ b/era5cli/key_management.py
@@ -92,9 +92,16 @@ def run_config(
     key: str,
 ) -> True:
     """Check the user-input configuration. Entry point for the CLI."""
-    attempt_cds_login(url, fullkey=f"{uid}:{key}")
-    write_era5cli_config(url, uid, key)
-    return True
+    try:
+        attempt_cds_login(url, fullkey=f"{uid}:{key}")
+        write_era5cli_config(url, uid, key)
+        return True
+    except InvalidLoginError:
+        print(
+            "Error: the UID and key are rejected by the CDS. "
+            "Please check and try again."
+        )
+    return False
 
 
 def check_era5cli_config() -> None:

--- a/era5cli/key_management.py
+++ b/era5cli/key_management.py
@@ -86,7 +86,7 @@ def attempt_cds_login(url: str, fullkey: str) -> True:
         raise err  # pragma: no cover
 
 
-def run_config(
+def set_config(
     url: str,
     uid: str,
     key: str,

--- a/era5cli/key_management.py
+++ b/era5cli/key_management.py
@@ -74,7 +74,7 @@ def attempt_cds_login(url: str, fullkey: str) -> True:
             raise InvalidLoginError(
                 f"{os.linesep}Authorization with the CDS served failed. Likely due to"
                 " an incorrect key or UID."
-                f"{os.linsep}Please check your era5cli configuration file: "
+                f"{os.linesep}Please check your era5cli configuration file: "
                 f"{ERA5CLI_CONFIG_PATH.resolve()}{os.linesep}"
                 "Or redefine your configuration with 'era5cli config'"
             ) from err

--- a/era5cli/key_management.py
+++ b/era5cli/key_management.py
@@ -46,10 +46,10 @@ def attempt_cds_login(url: str, fullkey: str) -> True:
 
     try:
         # Check the URL
-        connection.status()
+        connection.status()  # pragma: no cover
 
         # Checks if the authentication works, without downloading data
-        connection.retrieve(
+        connection.retrieve(  # pragma: no cover
             "reanalysis-era5-single-levels",
             {
                 "variable": "2t",

--- a/era5cli/key_management.py
+++ b/era5cli/key_management.py
@@ -1,0 +1,162 @@
+import cdsapi
+import os
+from pathlib import Path
+from requests.exceptions import ConnectionError  # pylint: disable=redefined-builtin
+from typing import Tuple
+
+
+ERA5CLI_CONFIG_PATH = Path.home() / ".config" / "era5cli.txt"
+CDSAPI_CONFIG_PATH = Path.home() / ".cdsapirc"
+DEFAULT_CDS_URL = "https://cds.climate.copernicus.eu/api/v2"
+
+AUTH_ERR_MSG = "401 Authorization Required"
+NO_DATA_ERR_MSG = "There is no data matching your request"
+
+
+class InvalidRequestError(Exception):
+    "Raised when an invalid request error is given by the cdsapi."
+
+
+class InvalidLoginError(Exception):
+    "Raised when an invalid login is provided to the cds server."
+
+
+def attempt_cds_login(url: str, fullkey: str) -> True:
+    """Attempt to connect to the CDS, to validate the URL and UID + key.
+
+    Args:
+        url: URL to the CDS API.
+        fullkey: Combination of your UID and key, separated with a colon.
+
+    Raises:
+        ConnectionError: If no connection to the CDS could be made.
+        InvalidLoginError: If an invalid authetication was provided to the CDS.
+        InvalidRequestError: If the test request failed, likely due to changes in the
+            CDS API's variable naming.
+
+    Returns:
+        True if a connection was made succesfully.
+    """
+    connection = cdsapi.Client(
+        url=url,
+        key=fullkey,
+        verify=True,
+        quiet=True,  # Supress output to the consolve from the test retrieve.
+    )
+
+    try:
+        # Check the URL
+        connection.status()
+
+        # Checks if the authentication works, without downloading data
+        connection.retrieve(
+            "reanalysis-era5-single-levels",
+            {
+                "variable": "2t",
+                "product_type": "reanalysis",
+                "date": "2012-12-01",
+                "time": "14:00",
+                "format": "netcdf",
+            },
+        )
+        return True
+
+    except ConnectionError as err:
+        raise ConnectionError(
+            "Failed to connect to CDS. Please check your internet connection and/or the"
+            f" URL in the era5cli configuration: {ERA5CLI_CONFIG_PATH.resolve()}" +
+            os.linesep + "Or redefine your configuration with 'era5cli config'"
+        ) from err
+
+    except Exception as err:
+        if AUTH_ERR_MSG in str(err):
+            raise InvalidLoginError(
+                os.linesep +
+                "Authorization with the CDS served failed. Likely due to an incorrect" +
+                " key or UID." +
+                os.linesep +
+                "Please check your era5cli configuration file: " +
+                f"{ERA5CLI_CONFIG_PATH.resolve()}" +
+                os.linesep +
+                "Or redefine your configuration with 'era5cli config'"
+            ) from err
+        if NO_DATA_ERR_MSG in str(err):
+            raise InvalidRequestError(
+                os.linesep +
+                "Something changed in the CDS API. Please raise an issue on "
+                "https://www.github.com/eWaterCycle/era5cli"
+            ) from err
+        raise err
+
+
+def run_config(url: str, uid: str, key: str,) -> True:
+    """Check the user-input configuration. Entry point for the CLI."""
+    attempt_cds_login(url, fullkey=f"{uid}:{key}")
+    write_era5cli_config(url, uid, key)
+    return True
+
+
+def check_era5cli_config() -> None:
+    """Validate if the era5cli config exists, and can connect to the CDS.
+
+    If no era5cli config file exists, but a CDS api file exists in the default location,
+    This routine will attempt to use those keys, and ask the user if they want to use
+    these.
+    """
+    if ERA5CLI_CONFIG_PATH.exists():
+        url, fullkey = load_era5cli_config()
+        attempt_cds_login(url, fullkey)
+    else:
+        print("era5cli configuration file not found. Looking for CDSAPI key.")
+        if not valid_cdsapi_config():
+            raise InvalidLoginError(
+                "No valid CDS login found. Please configure your CDS login using: "
+                "'era5cli config'"
+            )
+
+
+def valid_cdsapi_config() -> bool:
+    """Validate the default cdsapirc file. Promts the user for using these for era5cli.
+
+    Returns:
+        True if a valid key has been found & written to file. Otherwise False.
+    """
+    if CDSAPI_CONFIG_PATH.exists():
+        url, fullkey = load_cdsapi_config()
+        try:
+            if attempt_cds_login(url, fullkey):
+                userinput = input(
+                    "Valid CDS keys found in the .cdsapirc file. Do you want to use "
+                    "these for era5cli? [Y/n]"
+                )
+                if userinput in ["Y", "y", "Yes", "yes"]:
+                    write_era5cli_config(
+                        url, uid=fullkey.split(":")[0], key=fullkey.split(":")[1]
+                    )
+                    return True
+        except (ConnectionError, InvalidLoginError, InvalidRequestError):
+            return False
+    return False
+
+
+def load_era5cli_config() -> Tuple[str, str]:
+    with open(ERA5CLI_CONFIG_PATH, encoding="utf8") as f:
+        url = f.readline().replace("url:", "").strip()
+        uid = f.readline().replace("uid:", "").strip()
+        key = f.readline().replace("key:", "").strip()
+    return url, f"{uid}:{key}"
+
+
+def write_era5cli_config(url: str, uid: str, key: str):
+    ERA5CLI_CONFIG_PATH.parent.mkdir(exist_ok=True)
+    with open(ERA5CLI_CONFIG_PATH, mode="w", encoding="utf-8") as f:
+        f.write(f"url: {url}\n")
+        f.write(f"uid: {uid}\n")
+        f.write(f"key: {key}\n")
+
+
+def load_cdsapi_config() -> Tuple[str, str]:
+    with open(CDSAPI_CONFIG_PATH, encoding="utf-8") as f:
+        url = f.readline().replace("url:", "").strip()
+        fullkey = f.readline().replace("key:", "").strip()
+    return url, fullkey

--- a/era5cli/key_management.py
+++ b/era5cli/key_management.py
@@ -148,9 +148,9 @@ def load_era5cli_config() -> Tuple[str, str]:
     return url, f"{uid}:{key}"
 
 
-def write_era5cli_config(url: str, uid: str, key: str):
-    ERA5CLI_CONFIG_PATH.parent.mkdir(exist_ok=True)
-    with open(ERA5CLI_CONFIG_PATH, mode="w", encoding="utf-8") as f:
+def write_era5cli_config(url: str, uid: str, key: str, file_path=ERA5CLI_CONFIG_PATH):
+    file_path.parent.mkdir(exist_ok=True)
+    with open(file_path, mode="w", encoding="utf-8") as f:
         f.write(f"url: {url}\n")
         f.write(f"uid: {uid}\n")
         f.write(f"key: {key}\n")

--- a/era5cli/key_management.py
+++ b/era5cli/key_management.py
@@ -148,9 +148,9 @@ def load_era5cli_config() -> Tuple[str, str]:
     return url, f"{uid}:{key}"
 
 
-def write_era5cli_config(url: str, uid: str, key: str, file_path=ERA5CLI_CONFIG_PATH):
-    file_path.parent.mkdir(exist_ok=True)
-    with open(file_path, mode="w", encoding="utf-8") as f:
+def write_era5cli_config(url: str, uid: str, key: str):
+    ERA5CLI_CONFIG_PATH.parent.mkdir(exist_ok=True)
+    with open(ERA5CLI_CONFIG_PATH, mode="w", encoding="utf-8") as f:
         f.write(f"url: {url}\n")
         f.write(f"uid: {uid}\n")
         f.write(f"key: {key}\n")

--- a/era5cli/key_management.py
+++ b/era5cli/key_management.py
@@ -1,8 +1,8 @@
-import cdsapi
 import os
 from pathlib import Path
-from requests.exceptions import ConnectionError  # pylint: disable=redefined-builtin
 from typing import Tuple
+import cdsapi
+from requests.exceptions import ConnectionError  # pylint: disable=redefined-builtin
 
 
 ERA5CLI_CONFIG_PATH = Path.home() / ".config" / "era5cli.txt"
@@ -63,33 +63,34 @@ def attempt_cds_login(url: str, fullkey: str) -> True:
 
     except ConnectionError as err:
         raise ConnectionError(
-            "Failed to connect to CDS. Please check your internet connection and/or the"
-            f" URL in the era5cli configuration: {ERA5CLI_CONFIG_PATH.resolve()}" +
-            os.linesep + "Or redefine your configuration with 'era5cli config'"
+            f"{os.linesep}Failed to connect to CDS. Please check your internet "
+            "connection and/or the"
+            f" URL in the era5cli configuration: {ERA5CLI_CONFIG_PATH.resolve()}"
+            f"{os.linesep}Or redefine your configuration with 'era5cli config'"
         ) from err
 
     except Exception as err:
         if AUTH_ERR_MSG in str(err):
             raise InvalidLoginError(
-                os.linesep +
-                "Authorization with the CDS served failed. Likely due to an incorrect" +
-                " key or UID." +
-                os.linesep +
-                "Please check your era5cli configuration file: " +
-                f"{ERA5CLI_CONFIG_PATH.resolve()}" +
-                os.linesep +
+                f"{os.linesep}Authorization with the CDS served failed. Likely due to"
+                " an incorrect key or UID."
+                f"{os.linsep}Please check your era5cli configuration file: "
+                f"{ERA5CLI_CONFIG_PATH.resolve()}{os.linesep}"
                 "Or redefine your configuration with 'era5cli config'"
             ) from err
         if NO_DATA_ERR_MSG in str(err):
             raise InvalidRequestError(
-                os.linesep +
-                "Something changed in the CDS API. Please raise an issue on "
-                "https://www.github.com/eWaterCycle/era5cli"
+                f"{os.linesep}Something changed in the CDS API. Please raise an issue "
+                "on https://www.github.com/eWaterCycle/era5cli"
             ) from err
         raise err
 
 
-def run_config(url: str, uid: str, key: str,) -> True:
+def run_config(
+    url: str,
+    uid: str,
+    key: str,
+) -> True:
     """Check the user-input configuration. Entry point for the CLI."""
     attempt_cds_login(url, fullkey=f"{uid}:{key}")
     write_era5cli_config(url, uid, key)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,3 +121,11 @@ ignore = [
   "E203",  # Whitespace before ":". Not PEP8 compliant (https://github.com/psf/black/issues/315)
   "W503",  # https://peps.python.org/pep-0008/#should-a-line-break-before-or-after-a-binary-operator
 ]
+
+[tool.coverage.report]
+exclude_lines = [
+  "pragma: no cover",
+  "@overload",
+  "if TYPE_CHECKING:",
+  "if typing.TYPE_CHECKING:"
+]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import unittest.mock as mock
 import pytest
 import era5cli.cli as cli
 import era5cli.inputref as ref
+from era5cli import key_management
 
 
 def test_parse_args():
@@ -330,5 +331,20 @@ def test_config_parse():
 @mock.patch("era5cli.key_management.attempt_cds_login", return_value=True)
 @mock.patch("era5cli.key_management.write_era5cli_config")
 def test_config_write(mock_a, mock_b):
+    """Assuming the CDS login is valid, see if the write function is called"""
     args = cli._parse_args(config_args)
     cli._execute(args)
+
+
+@mock.patch(
+    "era5cli.key_management.attempt_cds_login",
+    side_effect=key_management.InvalidLoginError,
+)
+@mock.patch("era5cli.key_management.write_era5cli_config")
+def test_config_invalid(mock_a, mock_b, capfd):
+    """Assuming the CDS login is invalid, see if the right error is printed to console.
+    """
+    args = cli._parse_args(config_args)
+    cli._execute(args)
+    out, _ = capfd.readouterr()
+    assert "Error: the UID and key are rejected" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -333,6 +333,7 @@ def test_config_parse():
 def test_config_write(mock_a, mock_b):
     """Assuming the CDS login is valid, see if the write function is called"""
     args = cli._parse_args(config_args)
+    print(args)
     cli._execute(args)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,8 +3,8 @@
 import unittest.mock as mock
 import pytest
 import era5cli.args
-import era5cli.cli as cli
 import era5cli.inputref as ref
+from era5cli import cli
 from era5cli import key_management
 
 
@@ -28,7 +28,7 @@ def test_parse_args():
     assert args.endyear == 2008
     assert args.ensemble
     assert args.format == "netcdf"
-    assert args.hours == list(range(0, 24))
+    assert args.hours == list(range(24))
     assert args.levels == ref.PLEVELS
     assert args.months == list(range(1, 13))
     assert args.outputprefix == "era5"
@@ -151,7 +151,7 @@ def test_period_args():
         "--ensemble",
     ]
     args = cli._parse_args(argv)
-    period_args = cli._set_period_args(args)
+    period_args = era5cli.args.periods.set_period_args(args)
     # Period_args consists of (synoptic, statistics, days, hours)
     assert period_args == (None, None, None, [0])
 
@@ -167,7 +167,7 @@ def test_period_args():
         "--ensemble",
     ]
     args = cli._parse_args(argv)
-    period_args = cli._set_period_args(args)
+    period_args = era5cli.args.periods.set_period_args(args)
     # Period_args consists of (synoptic, statistics, days, hours)
     assert period_args == (True, None, None, [4, 7])
 
@@ -181,15 +181,15 @@ def test_period_args():
         "--ensemble",
     ]
     args = cli._parse_args(argv)
-    period_args = cli._set_period_args(args)
+    period_args = era5cli.args.periods.set_period_args(args)
     # Period_args consists of (synoptic, statistics, days, hours)
-    assert period_args == (True, None, None, range(0, 24))
+    assert period_args == (True, None, None, range(24))
 
-    # test whether the info option does not end up in _set_period_args
+    # test whether the info option does not end up in set_period_args
     argv = ["info", "2Dvars"]
     args = cli._parse_args(argv)
     with pytest.raises(AttributeError):
-        assert cli._set_period_args(args)
+        assert era5cli.args.periods.set_period_args(args)
 
 
 def test_level_arguments():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -152,8 +152,8 @@ def test_period_args():
     ]
     args = cli._parse_args(argv)
     period_args = era5cli.args.periods.set_period_args(args)
-    # Period_args consists of (synoptic, statistics, days, hours)
-    assert period_args == (None, None, None, [0])
+    # Period_args consists of (synoptic, statistics, splitmonths, days, hours)
+    assert period_args == (None, None, False, None, [0])
 
     argv = [
         "monthly",
@@ -168,8 +168,8 @@ def test_period_args():
     ]
     args = cli._parse_args(argv)
     period_args = era5cli.args.periods.set_period_args(args)
-    # Period_args consists of (synoptic, statistics, days, hours)
-    assert period_args == (True, None, None, [4, 7])
+    # Period_args consists of (synoptic, statistics, splitmonths, days, hours)
+    assert period_args == (True, None, False, None, [4, 7])
 
     argv = [
         "monthly",
@@ -183,7 +183,7 @@ def test_period_args():
     args = cli._parse_args(argv)
     period_args = era5cli.args.periods.set_period_args(args)
     # Period_args consists of (synoptic, statistics, days, hours)
-    assert period_args == (True, None, None, range(24))
+    assert period_args == (True, None, False, None, range(24))
 
     # test whether the info option does not end up in set_period_args
     argv = ["info", "2Dvars"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -313,12 +313,12 @@ def test_main_info(info):
 
 
 config_args = [
-        "config",
-        "--uid",
-        "123456",
-        "--key",
-        "abc-def",
-    ]
+    "config",
+    "--uid",
+    "123456",
+    "--key",
+    "abc-def",
+]
 
 
 def test_config_parse():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -342,8 +342,7 @@ def test_config_write(mock_a, mock_b):
 )
 @mock.patch("era5cli.key_management.write_era5cli_config")
 def test_config_invalid(mock_a, mock_b, capfd):
-    """Assuming the CDS login is invalid, see if the right error is printed to console.
-    """
+    """Assume the CDS login is invalid, see if the right error is printed to console."""
     args = cli._parse_args(config_args)
     cli._execute(args)
     out, _ = capfd.readouterr()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -310,3 +310,25 @@ def test_main_info(info):
     argv = ["info", "total_precipitation"]
     args = cli._parse_args(argv)
     cli._execute(args)
+
+
+config_args = [
+        "config",
+        "--uid",
+        "123456",
+        "--key",
+        "abc-def",
+    ]
+
+
+def test_config_parse():
+    args = cli._parse_args(config_args)
+    assert args.uid == "123456"
+    assert args.key == "abc-def"
+
+
+@mock.patch("era5cli.key_management.attempt_cds_login", return_value=True)
+@mock.patch("era5cli.key_management.write_era5cli_config")
+def test_config_write(mock_a, mock_b):
+    args = cli._parse_args(config_args)
+    cli._execute(args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,10 +2,11 @@
 
 import unittest.mock as mock
 import pytest
+import era5cli.args
 import era5cli.cli as cli
 import era5cli.inputref as ref
 from era5cli import key_management
-import era5cli.args
+
 
 def test_parse_args():
     """Test argument parser of cli."""
@@ -351,15 +352,16 @@ def test_config_invalid(mock_a, mock_b, capfd):
 
 class TestConfigControlFlow:
     """Test the args.config.config_control_flow function."""
+
     @mock.patch(
         "era5cli.key_management.load_era5cli_config",
-        return_value=("https://www.test.org/", "123:abc-def")
+        return_value=("https://www.test.org/", "123:abc-def"),
     )
     def test_config_show(self, mock, capsys):
         args = cli._parse_args(["config", "--show"])
         cli._execute(args)
 
-        expected =  (
+        expected = (
             "Contents of .config/era5cli.txt:\n"
             "    uid: 123\n"
             "    key: abc-def\n"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,6 +31,7 @@ def valid_path_cds(tmp_path_factory):
 
 
 class TestEra5CliConfig:
+    """Test the functionality when the /.config/era5cli.txt file exists."""
     def test_load_era5cli_config(self, valid_path_era5):
         with patch("era5cli.key_management.ERA5CLI_CONFIG_PATH", valid_path_era5):
             assert key_management.load_era5cli_config() == ("b", "123:abc-def")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -86,19 +86,19 @@ class TestConfigCdsrc:
                 key_management.check_era5cli_config()
 
 
-class AttemptCdsLogin:
+class TestAttemptCdsLogin:
     """Test the keymanagement.attempt_cds_login function.
 
     attempt_cds_login is monkeypatched elsewhere, these tests ensure it works as
     expected.
     """
 
-    def test_status_fail():
+    def test_status_fail(self):
         with patch("cdsapi.Client.status", side_effect=rex.ConnectionError):
             with pytest.raises(rex.ConnectionError, match="Failed to connect to CDS"):
                 key_management.attempt_cds_login(url="test", fullkey="abc:def")
 
-    def test_connection_fail():
+    def test_connection_fail(self):
         mp1 = patch("cdsapi.Client.status")
         mp2 = patch(
             "cdsapi.Client.retrieve",
@@ -111,7 +111,7 @@ class AttemptCdsLogin:
             ):
                 key_management.attempt_cds_login(url="test", fullkey="abc:def")
 
-    def test_retrieve_fail():
+    def test_retrieve_fail(self):
         mp1 = patch("cdsapi.Client.status")
         mp2 = patch(
             "cdsapi.Client.retrieve",
@@ -124,7 +124,7 @@ class AttemptCdsLogin:
             ):
                 key_management.attempt_cds_login(url="test", fullkey="abc:def")
 
-    def test_all_pass():
+    def test_all_pass(self):
         mp1 = patch("cdsapi.Client.status")
         mp2 = patch("cdsapi.Client.retrieve")
         with mp1, mp2:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 import pytest
 from era5cli import key_management
-
+import sys
 
 @pytest.fixture(scope="function")
 def config_path_era5(tmp_path_factory):
@@ -10,12 +10,13 @@ def config_path_era5(tmp_path_factory):
 
 @pytest.fixture(scope="function")
 def config_path_cds(tmp_path_factory):
-    fn = tmp_path_factory.mktemp(".config") / ".cdsapirc"
+    fn = tmp_path_factory.mktemp(".config") / "cdsapirc.txt"
     with open(fn, mode="w", encoding="utf-8") as f:
         f.write("url: a\nkey: 123:abc-def")
     return fn
 
 
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="Parenthesized context managers")
 class TestConfig:
     def test_check_cdsrc_no(self, config_path_era5, config_path_cds):
         """.cdsapirc exists. User says no. Should raise InvalidLoginError"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,58 +1,125 @@
-import sys
 from unittest.mock import patch
 import pytest
+import requests.exceptions as rex
 from era5cli import key_management
 
 
 @pytest.fixture(scope="function")
-def config_path_era5(tmp_path_factory):
+def empty_path_era5(tmp_path_factory):
     return tmp_path_factory.mktemp(".config") / "era5cli.txt"
 
 
 @pytest.fixture(scope="function")
-def config_path_cds(tmp_path_factory):
+def valid_path_era5(tmp_path_factory):
+    fn = tmp_path_factory.mktemp(".config") / "era5cli.txt"
+    with open(fn, mode="w", encoding="utf-8") as f:
+        f.write("url: b\nuid: 123\nkey: abc-def\n")
+    return fn
+
+
+@pytest.fixture(scope="function")
+def empty_path_cds(tmp_path_factory):
+    return tmp_path_factory.mktemp(".config") / "cdsapirc.txt"
+
+
+@pytest.fixture(scope="function")
+def valid_path_cds(tmp_path_factory):
     fn = tmp_path_factory.mktemp(".config") / "cdsapirc.txt"
     with open(fn, mode="w", encoding="utf-8") as f:
         f.write("url: a\nkey: 123:abc-def")
     return fn
 
 
-@pytest.mark.skipif(sys.version_info < (3, 9), reason="Parenthesized context managers")
-class TestConfig:
-    def test_check_cdsrc_no(self, config_path_era5, config_path_cds):
+class TestEra5CliConfig:
+    def test_load_era5cli_config(self, valid_path_era5):
+        with patch("era5cli.key_management.ERA5CLI_CONFIG_PATH", valid_path_era5):
+            assert key_management.load_era5cli_config() == ("b", "123:abc-def")
+
+    def test_check_era5cli_config(self, valid_path_era5):
+        mp1 = patch("era5cli.key_management.ERA5CLI_CONFIG_PATH", valid_path_era5)
+        mp2 = patch("era5cli.key_management.attempt_cds_login", return_value=True)
+        with mp1, mp2:
+            key_management.attempt_cds_login()
+
+
+class TestConfigCdsrc:
+    """Test the cases where a .cdsapirc file exists.
+
+    This leads to three options:
+        - File exists, the keys are valid, and user does not want to copy the keys.
+        - File exists, the keys are valid, and the users wants to copy the keys.
+        - File exists, and the keys are not valid.
+    """
+
+    def test_cdsrcfile_user_says_no(self, empty_path_era5, valid_path_cds):
         """.cdsapirc exists. User says no. Should raise InvalidLoginError"""
-        with (
-            patch("builtins.input", return_value="N"),
-            patch("era5cli.key_management.attempt_cds_login", return_value=True),
-            patch("era5cli.key_management.ERA5CLI_CONFIG_PATH", config_path_era5),
-            patch("era5cli.key_management.CDSAPI_CONFIG_PATH", config_path_cds),
-        ):
+        mp1 = patch("builtins.input", return_value="N")
+        mp2 = patch("era5cli.key_management.attempt_cds_login", return_value=True)
+        mp3 = patch("era5cli.key_management.ERA5CLI_CONFIG_PATH", empty_path_era5)
+        mp4 = patch("era5cli.key_management.CDSAPI_CONFIG_PATH", valid_path_cds)
+        with mp1, mp2, mp3, mp4:
             with pytest.raises(
                 key_management.InvalidLoginError, match="No valid CDS login found"
             ):
                 key_management.check_era5cli_config()
 
-    def test_check_cdsrc_yes(self, config_path_era5, config_path_cds):
+    def test_cdsrcfile_user_says_yes(self, empty_path_era5, valid_path_cds):
         """.cdsapirc exists. User says yes. url+key is copied to the era5cli config."""
-        with (
-            patch("builtins.input", return_value="Y"),
-            patch("era5cli.key_management.attempt_cds_login", return_value=True),
-            patch("era5cli.key_management.ERA5CLI_CONFIG_PATH", config_path_era5),
-            patch("era5cli.key_management.CDSAPI_CONFIG_PATH", config_path_cds),
-        ):
+        mp1 = patch("builtins.input", return_value="Y")
+        mp2 = patch("era5cli.key_management.attempt_cds_login", return_value=True)
+        mp3 = patch("era5cli.key_management.ERA5CLI_CONFIG_PATH", empty_path_era5)
+        mp4 = patch("era5cli.key_management.CDSAPI_CONFIG_PATH", valid_path_cds)
+        with mp1, mp2, mp3, mp4:
             key_management.check_era5cli_config()
-            with open(config_path_era5, "r", encoding="utf-8") as f:
+            with open(empty_path_era5, "r", encoding="utf-8") as f:
                 assert f.readlines() == ["url: a\n", "uid: 123\n", "key: abc-def\n"]
 
-    def test_check_cdsrc_yes_fail(self, config_path_era5, config_path_cds):
-        """.cdsapirc exists. User says yes. url+key is validated, and is bad."""
-        with (
-            patch("builtins.input", return_value="Y"),
-            patch("era5cli.key_management.attempt_cds_login", return_value=False),
-            patch("era5cli.key_management.ERA5CLI_CONFIG_PATH", config_path_era5),
-            patch("era5cli.key_management.CDSAPI_CONFIG_PATH", config_path_cds),
-        ):
+    def test_cdsrcfile_invalid_keys(self, empty_path_era5, valid_path_cds):
+        """.cdsapirc exists. url+key is validated, and is bad."""
+        mp1 = patch("era5cli.key_management.attempt_cds_login", return_value=False)
+        mp2 = patch("era5cli.key_management.ERA5CLI_CONFIG_PATH", empty_path_era5)
+        mp3 = patch("era5cli.key_management.CDSAPI_CONFIG_PATH", valid_path_cds)
+        with mp1, mp2, mp3:
             with pytest.raises(
                 key_management.InvalidLoginError, match="No valid CDS login found"
             ):
                 key_management.check_era5cli_config()
+
+
+class AttemptCdsLogin:
+    """Test the keymanagement.attempt_cds_login function.
+
+    attempt_cds_login is monkeypatched elsewhere, these tests ensure it works as
+    expected.
+    """
+
+    def test_status_fail():
+        with patch("cdsapi.Client.status", side_effect=rex.ConnectionError):
+            with pytest.raises(rex.ConnectionError, match="Failed to connect to CDS"):
+                key_management.attempt_cds_login(url="test", fullkey="abc:def")
+
+    def test_connection_fail():
+        mp1 = patch("cdsapi.Client.status")
+        mp2 = patch(
+            "cdsapi.Client.retrieve",
+            side_effect=Exception("401 Authorization Required"),
+        )
+        with mp1, mp2:
+            with pytest.raises(
+                key_management.InvalidLoginError,
+                match="Authorization with the CDS served failed",
+            ):
+                key_management.attempt_cds_login(url="test", fullkey="abc:def")
+
+    def test_retrieve_fail():
+        mp1 = patch("cdsapi.Client.status")
+        mp2 = patch(
+            "cdsapi.Client.retrieve",
+            side_effect=Exception("There is no data matching your request"),
+        )
+        with mp1, mp2:
+            with pytest.raises(
+                key_management.InvalidRequestError,
+                match="Something changed in the CDS API",
+            ):
+                key_management.attempt_cds_login(url="test", fullkey="abc:def")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -123,3 +123,11 @@ class AttemptCdsLogin:
                 match="Something changed in the CDS API",
             ):
                 key_management.attempt_cds_login(url="test", fullkey="abc:def")
+
+    def test_all_pass():
+        mp1 = patch("cdsapi.Client.status")
+        mp2 = patch("cdsapi.Client.retrieve")
+        with mp1, mp2:
+            assert (
+                key_management.attempt_cds_login(url="test", fullkey="abc:def") is True
+            )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -39,7 +39,7 @@ class TestEra5CliConfig:
         mp1 = patch("era5cli.key_management.ERA5CLI_CONFIG_PATH", valid_path_era5)
         mp2 = patch("era5cli.key_management.attempt_cds_login", return_value=True)
         with mp1, mp2:
-            key_management.attempt_cds_login()
+            key_management.check_era5cli_config()
 
 
 class TestConfigCdsrc:
@@ -76,7 +76,10 @@ class TestConfigCdsrc:
 
     def test_cdsrcfile_invalid_keys(self, empty_path_era5, valid_path_cds):
         """.cdsapirc exists. url+key is validated, and is bad."""
-        mp1 = patch("era5cli.key_management.attempt_cds_login", return_value=False)
+        mp1 = patch(
+            "era5cli.key_management.attempt_cds_login",
+            side_effect=key_management.InvalidLoginError,
+        )
         mp2 = patch("era5cli.key_management.ERA5CLI_CONFIG_PATH", empty_path_era5)
         mp3 = patch("era5cli.key_management.CDSAPI_CONFIG_PATH", valid_path_cds)
         with mp1, mp2, mp3:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,6 +32,7 @@ def valid_path_cds(tmp_path_factory):
 
 class TestEra5CliConfig:
     """Test the functionality when the /.config/era5cli.txt file exists."""
+
     def test_load_era5cli_config(self, valid_path_era5):
         with patch("era5cli.key_management.ERA5CLI_CONFIG_PATH", valid_path_era5):
             assert key_management.load_era5cli_config() == ("b", "123:abc-def")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
-from era5cli import key_management
 import pytest
+from era5cli import key_management
 
 
 @pytest.fixture(scope="function")
@@ -24,7 +24,7 @@ class TestConfig:
             patch("era5cli.key_management.attempt_cds_login", return_value=True),
             patch("era5cli.key_management.ERA5CLI_CONFIG_PATH", config_path_era5),
             patch("era5cli.key_management.CDSAPI_CONFIG_PATH", config_path_cds),
-            ):
+        ):
             with pytest.raises(key_management.InvalidLoginError):
                 key_management.check_era5cli_config()
 
@@ -35,7 +35,7 @@ class TestConfig:
             patch("era5cli.key_management.attempt_cds_login", return_value=True),
             patch("era5cli.key_management.ERA5CLI_CONFIG_PATH", config_path_era5),
             patch("era5cli.key_management.CDSAPI_CONFIG_PATH", config_path_cds),
-            ):
+        ):
             key_management.check_era5cli_config()
             with open(config_path_era5, "r", encoding="utf-8") as f:
                 assert f.readlines() == ["url: a\n", "uid: 123\n", "key: abc-def\n"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,41 @@
+from unittest.mock import patch
+from era5cli import key_management
+import pytest
+
+
+@pytest.fixture(scope="function")
+def config_path_era5(tmp_path_factory):
+    return tmp_path_factory.mktemp(".config") / "era5cli.txt"
+
+
+@pytest.fixture(scope="function")
+def config_path_cds(tmp_path_factory):
+    fn = tmp_path_factory.mktemp(".config") / ".cdsapirc"
+    with open(fn, mode="w", encoding="utf-8") as f:
+        f.write("url: a\nkey: 123:abc-def")
+    return fn
+
+
+class TestConfig:
+    def test_check_cdsrc_no(self, config_path_era5, config_path_cds):
+        """.cdsapirc exists. User says no. Should raise InvalidLoginError"""
+        with (
+            patch("builtins.input", return_value="N"),
+            patch("era5cli.key_management.attempt_cds_login", return_value=True),
+            patch("era5cli.key_management.ERA5CLI_CONFIG_PATH", config_path_era5),
+            patch("era5cli.key_management.CDSAPI_CONFIG_PATH", config_path_cds),
+            ):
+            with pytest.raises(key_management.InvalidLoginError):
+                key_management.check_era5cli_config()
+
+    def test_check_cdsrc_yes(self, config_path_era5, config_path_cds):
+        """.cdsapirc exists. User says yes. url+key is copied to the era5cli config."""
+        with (
+            patch("builtins.input", return_value="Y"),
+            patch("era5cli.key_management.attempt_cds_login", return_value=True),
+            patch("era5cli.key_management.ERA5CLI_CONFIG_PATH", config_path_era5),
+            patch("era5cli.key_management.CDSAPI_CONFIG_PATH", config_path_cds),
+            ):
+            key_management.check_era5cli_config()
+            with open(config_path_era5, "r", encoding="utf-8") as f:
+                assert f.readlines() == ["url: a\n", "uid: 123\n", "key: abc-def\n"]

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -21,7 +21,6 @@ ALL_DAYS = [
 ALL_MONTHS = ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"]
 # fmt: on
 
-
 def initialize(
     outputformat="netcdf",
     merge=False,
@@ -40,29 +39,36 @@ def initialize(
     prelimbe=False,
     land=False,
 ):
-    """Initializer of the class."""
-    return fetch.Fetch(
-        years=years,
-        months=months,
-        days=days,
-        hours=hours,
-        area=area,
-        variables=variables,
-        outputformat=outputformat,
-        outputprefix="era5",
-        period=period,
-        ensemble=ensemble,
-        statistics=statistics,
-        synoptic=synoptic,
-        pressurelevels=pressurelevels,
-        merge=merge,
-        threads=threads,
-        prelimbe=prelimbe,
-        land=land,
-    )
+    with mock.patch(
+        "era5cli.fetch.key_management.load_era5cli_config",
+        return_value=("url", "key:uid")
+    ):
+        """Initializer of the class."""
+        return fetch.Fetch(
+            years=years,
+            months=months,
+            days=days,
+            hours=hours,
+            area=area,
+            variables=variables,
+            outputformat=outputformat,
+            outputprefix="era5",
+            period=period,
+            ensemble=ensemble,
+            statistics=statistics,
+            synoptic=synoptic,
+            pressurelevels=pressurelevels,
+            merge=merge,
+            threads=threads,
+            prelimbe=prelimbe,
+            land=land,
+        )
 
-
-def test_init():
+@mock.patch(
+    "era5cli.fetch.key_management.load_era5cli_config",
+    return_value=("url", "key:uid")
+)
+def test_init(load_era5cli_config):
     """Test init function of Fetch class."""
     era5 = fetch.Fetch(
         years=[2008, 2009],

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -21,6 +21,7 @@ ALL_DAYS = [
 ALL_MONTHS = ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"]
 # fmt: on
 
+
 def initialize(
     outputformat="netcdf",
     merge=False,
@@ -41,7 +42,7 @@ def initialize(
 ):
     with mock.patch(
         "era5cli.fetch.key_management.load_era5cli_config",
-        return_value=("url", "key:uid")
+        return_value=("url", "key:uid"),
     ):
         """Initializer of the class."""
         return fetch.Fetch(
@@ -64,9 +65,9 @@ def initialize(
             land=land,
         )
 
+
 @mock.patch(
-    "era5cli.fetch.key_management.load_era5cli_config",
-    return_value=("url", "key:uid")
+    "era5cli.fetch.key_management.load_era5cli_config", return_value=("url", "key:uid")
 )
 def test_init(load_era5cli_config):
     """Test init function of Fetch class."""

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -258,16 +258,17 @@ def test_define_outputfilename():
 
 _vars = ["total_precipitation", "runoff"]
 _years = [2007, 2008, 2009]
+
+
 @pytest.mark.parametrize(
     "variables, years, merge, ensemble, expected",
     [
-        (_vars[:2], _years[:3], False, False, 2*3),
-        (_vars[:2], _years[:3], True, False, 2), # Test merge
-        (_vars[:2], _years[:3], False, True, 2*3*12),
-        (_vars[:2], _years[:1], False, False, 2*1),
-        (_vars[:1], _years[:3], False, False, 1*3),
-
-    ]
+        (_vars[:2], _years[:3], False, False, 2 * 3),
+        (_vars[:2], _years[:3], True, False, 2),  # Test merge
+        (_vars[:2], _years[:3], False, True, 2 * 3 * 12),
+        (_vars[:2], _years[:1], False, False, 2 * 1),
+        (_vars[:1], _years[:3], False, False, 1 * 3),
+    ],
 )
 def test_number_outputfiles(capsys, variables, years, merge, ensemble, expected):
     """Test function for the number of outputs."""

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -2,6 +2,7 @@
 
 import unittest.mock as mock
 import pytest
+from era5cli import _request_size
 from era5cli import fetch
 
 
@@ -119,6 +120,14 @@ def test_init(mockpatch):
         variables=["temperature"], period="monthly", days=None, pressurelevels=[1]
     )
     assert isinstance(era5, fetch.Fetch)
+
+    with pytest.raises(_request_size.TooLargeRequestError):
+        initialize(
+            land=True, variables=["skin_temperature"], ensemble=False, splitmonths=False
+        )
+
+    with pytest.raises(ValueError, match="are not compatible"):
+        initialize(merge=True, splitmonths=True)
 
 
 @mock.patch("cdsapi.Client", autospec=True)

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -256,52 +256,32 @@ def test_define_outputfilename():
     assert fname == fn
 
 
-def test_number_outputfiles(capsys):
+_vars = ["total_precipitation", "runoff"]
+_years = [2007, 2008, 2009]
+@pytest.mark.parametrize(
+    "variables, years, merge, ensemble, expected",
+    [
+        (_vars[:2], _years[:3], False, False, 2*3),
+        (_vars[:2], _years[:3], True, False, 2), # Test merge
+        (_vars[:2], _years[:3], False, True, 2*3*12),
+        (_vars[:2], _years[:1], False, False, 2*1),
+        (_vars[:1], _years[:3], False, False, 1*3),
+
+    ]
+)
+def test_number_outputfiles(capsys, variables, years, merge, ensemble, expected):
     """Test function for the number of outputs."""
     # two variables and three years
     era5 = initialize(
-        variables=["total_precipitation", "runoff"],
-        years=[2007, 2008, 2009],
-        merge=False,
+        variables=variables,
+        years=years,
+        merge=merge,
+        ensemble=ensemble,
     )
     era5.fetch(dryrun=True)
     captured = capsys.readouterr()
     outputlength = len(captured.out.split("\n")) - 1
-    if not era5.merge:
-        # No. of outputs is 2*3 = 6 if merge = False
-        assert outputlength == len(era5.years) * len(era5.variables)
-    else:
-        # No. of outputs is 2*1 = 2 if merge = True
-        assert outputlength == len(era5.variables)
-
-    # one variable and three years
-    era5 = initialize(
-        variables=["total_precipitation"], years=[2007, 2008, 2009], merge=False
-    )
-    era5.fetch(dryrun=True)
-    captured = capsys.readouterr()
-    outputlength = len(captured.out.split("\n")) - 1
-    if not era5.merge:
-        # No. of outputs is 1*3 = 3 if merge = False
-        assert outputlength == len(era5.years) * len(era5.variables)
-    else:
-        # No. of outputs is 1 if merge = True
-        assert outputlength == len(era5.variables)
-
-    # two variables and one year
-    era5 = initialize(
-        variables=["total_precipitation", "runoff"], years=[2007], merge=False
-    )
-    era5.fetch(dryrun=True)
-    captured = capsys.readouterr()
-    outputlength = len(captured.out.split("\n")) - 1
-    if not era5.merge:
-        # No. of outputs is 2*1 = 2 if merge = False
-        assert outputlength == len(era5.years) * len(era5.variables)
-    else:
-        # No. of outputs is 2 if merge = True
-        assert outputlength == len(era5.variables)
-    del era5, captured
+    assert outputlength == expected
 
 
 def test_product_type():

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -39,6 +39,7 @@ def initialize(
     hours=list(range(24)),
     prelimbe=False,
     land=False,
+    splitmonths=False,
 ):
     with mock.patch(
         "era5cli.fetch.key_management.load_era5cli_config",
@@ -63,13 +64,14 @@ def initialize(
             threads=threads,
             prelimbe=prelimbe,
             land=land,
+            splitmonths=splitmonths,
         )
 
 
 @mock.patch(
     "era5cli.fetch.key_management.load_era5cli_config", return_value=("url", "key:uid")
 )
-def test_init(load_era5cli_config):
+def test_init(mockpatch):
     """Test init function of Fetch class."""
     era5 = fetch.Fetch(
         years=[2008, 2009],
@@ -83,7 +85,7 @@ def test_init(load_era5cli_config):
         ensemble=True,
         statistics=None,
         synoptic=None,
-        pressurelevels=None,
+        pressurelevels="surface",
         merge=False,
         threads=2,
         prelimbe=False,
@@ -100,7 +102,7 @@ def test_init(load_era5cli_config):
     assert era5.ensemble
     assert era5.statistics is None
     assert era5.synoptic is None
-    assert era5.pressure_levels is None
+    assert era5.pressure_levels == "surface"
     assert not era5.merge
     assert era5.threads == 2
     assert not era5.prelimbe
@@ -108,10 +110,14 @@ def test_init(load_era5cli_config):
 
     # initializing hourly variable with days=None should result in ValueError
     with pytest.raises(TypeError):
-        era5 = initialize(variables=["temperature"], period="hourly", days=None)
+        era5 = initialize(
+            variables=["temperature"], period="hourly", days=None, pressurelevels=[1]
+        )
 
     # initializing monthly variable with days=None returns fetch.Fetch object
-    era5 = initialize(variables=["temperature"], period="monthly", days=None)
+    era5 = initialize(
+        variables=["temperature"], period="monthly", days=None, pressurelevels=[1]
+    )
     assert isinstance(era5, fetch.Fetch)
 
 
@@ -153,15 +159,14 @@ def test_fetch_nodryrun(cds, era5cli_utilsappend_history):
     assert era5.fetch() is None
 
     # invalid pressure level should raise ValueError
-    era5 = initialize(
-        outputformat="grib",
-        merge=True,
-        threads=None,
-        pressurelevels=[1, 2, 9],
-        variables=["temperature"],
-    )
     with pytest.raises(ValueError):
-        assert era5.fetch()
+        era5 = initialize(
+            outputformat="grib",
+            merge=True,
+            threads=None,
+            pressurelevels=[1, 2, 9],
+            variables=["temperature"],
+        )
 
     # invalid variable name should raise ValueError
     era5 = initialize(
@@ -234,25 +239,25 @@ def test_define_outputfilename():
     fn = "era5_total_precipitation_2008-2009_hourly_ensemble_synoptic.grb"
     assert fname == fn
 
-    era5 = initialize(land=True, ensemble=False)
+    era5 = initialize(land=True, ensemble=False, splitmonths=True)
     era5._extension()
-    fname = era5._define_outputfilename("total_precipitation", [2008])
-    fn = "era5-land_total_precipitation_2008_hourly.nc"
+    fname = era5._define_outputfilename("total_precipitation", [2008], month="01")
+    fn = "era5-land_total_precipitation_2008-01_hourly.nc"
     assert fname == fn
 
     era5.area = [90.0, -180.0, -90.0, 180.0]
-    fname = era5._define_outputfilename("total_precipitation", [2008])
-    fn = "era5-land_total_precipitation_2008_hourly_180W-180E_90S-90N.nc"
+    fname = era5._define_outputfilename("total_precipitation", [2008], month="01")
+    fn = "era5-land_total_precipitation_2008-01_hourly_180W-180E_90S-90N.nc"
     assert fname == fn
 
     era5.area = [90.0, -180.0, -80.999, 170.001]
-    fname = era5._define_outputfilename("total_precipitation", [2008])
-    fn = "era5-land_total_precipitation_2008_hourly_180W-170E_81S-90N.nc"
+    fname = era5._define_outputfilename("total_precipitation", [2008], month="01")
+    fn = "era5-land_total_precipitation_2008-01_hourly_180W-170E_81S-90N.nc"
     assert fname == fn
 
     era5.area = [0, 120, -90, 180]
-    fname = era5._define_outputfilename("total_precipitation", [2008])
-    fn = "era5-land_total_precipitation_2008_hourly_120E-180E_90S-0N.nc"
+    fname = era5._define_outputfilename("total_precipitation", [2008], month="01")
+    fn = "era5-land_total_precipitation_2008-01_hourly_120E-180E_90S-0N.nc"
     assert fname == fn
 
 
@@ -261,16 +266,19 @@ _years = [2007, 2008, 2009]
 
 
 @pytest.mark.parametrize(
-    "variables, years, merge, ensemble, expected",
+    "variables, years, merge, ensemble, splitmonths, expected",
     [
-        (_vars[:2], _years[:3], False, False, 2 * 3),
-        (_vars[:2], _years[:3], True, False, 2),  # Test merge
-        (_vars[:2], _years[:3], False, True, 2 * 3 * 12),
-        (_vars[:2], _years[:1], False, False, 2 * 1),
-        (_vars[:1], _years[:3], False, False, 1 * 3),
+        (_vars, _years, False, False, False, 2 * 3),
+        (_vars, _years, True, False, False, 2),  # Test merge
+        (_vars, _years, False, True, False, 2 * 3),  # Current default
+        (_vars, _years, False, True, True, 2 * 3 * 12),  # Future default
+        (_vars, _years[:1], False, False, False, 2 * 1),
+        (_vars[:1], _years, False, False, False, 1 * 3),
     ],
 )
-def test_number_outputfiles(capsys, variables, years, merge, ensemble, expected):
+def test_number_outputfiles(
+    capsys, variables, years, merge, ensemble, splitmonths, expected
+):
     """Test function for the number of outputs."""
     # two variables and three years
     era5 = initialize(
@@ -278,11 +286,14 @@ def test_number_outputfiles(capsys, variables, years, merge, ensemble, expected)
         years=years,
         merge=merge,
         ensemble=ensemble,
+        splitmonths=splitmonths,
     )
     era5.fetch(dryrun=True)
     captured = capsys.readouterr()
-    outputlength = len(captured.out.split("\n")) - 1
-    assert outputlength == expected
+
+    # Every request has 'product_type' in it once, ie. the number of requests equals:
+    nrequests = captured.out.count("product_type")
+    assert nrequests == expected
 
 
 def test_product_type():
@@ -539,9 +550,8 @@ def test_build_request():
     assert request == req
 
     # requesting 3d variable with pressurelevels=None should give a ValueError
-    era5 = initialize(variables=["temperature"], pressurelevels=None)
     with pytest.raises(ValueError):
-        assert era5._build_request("temperature", [2008])
+        era5 = initialize(variables=["temperature"], pressurelevels=None)
 
     # requesting data from orography should call geopotential
     era5 = initialize()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,9 +2,10 @@
 
 import logging
 from textwrap import dedent
+from unittest import mock
 import pytest
 from era5cli.cli import main
-from unittest import mock
+
 
 # combine calls with result and possible warning message
 call_result = [
@@ -136,11 +137,11 @@ def test_main(call_result, capsys, caplog):
     if "--dryrun" not in call:
         pytest.fail("call must be a dryrun")
     with caplog.at_level(logging.INFO):
-            with mock.patch(
-                "era5cli.fetch.key_management.load_era5cli_config",
-                return_value=("url", "key:uid")
-            ):
-                main(call)
+        with mock.patch(
+            "era5cli.fetch.key_management.load_era5cli_config",
+            return_value=("url", "key:uid"),
+        ):
+            main(call)
     captured = capsys.readouterr().out
     assert result == captured
     try:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,7 +4,7 @@ import logging
 from textwrap import dedent
 import pytest
 from era5cli.cli import main
-
+from unittest import mock
 
 # combine calls with result and possible warning message
 call_result = [
@@ -136,7 +136,11 @@ def test_main(call_result, capsys, caplog):
     if "--dryrun" not in call:
         pytest.fail("call must be a dryrun")
     with caplog.at_level(logging.INFO):
-        main(call)
+            with mock.patch(
+                "era5cli.fetch.key_management.load_era5cli_config",
+                return_value=("url", "key:uid")
+            ):
+                main(call)
     captured = capsys.readouterr().out
     assert result == captured
     try:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -57,16 +57,16 @@ call_result = [
     },
     {
         # without --levels surface, geopotential calls pressure level data
+        # Note: only request a single month to avoid TooLargeRequest
         "call": dedent(
             """\
-            era5cli hourly --variables geopotential --startyear 2008
+            era5cli hourly --variables geopotential --startyear 2008 --months 01
             --dryrun"""
         ),
         "result": dedent(
             """\
             reanalysis-era5-pressure-levels {'variable': 'geopotential',
-            'year': 2008, 'month': ['01', '02', '03', '04', '05', '06', '07',
-            '08', '09', '10', '11', '12'], 'time': ['00:00', '01:00', '02:00',
+            'year': 2008, 'month': ['01'], 'time': ['00:00', '01:00', '02:00',
             '03:00', '04:00', '05:00', '06:00', '07:00', '08:00', '09:00',
             '10:00', '11:00', '12:00', '13:00', '14:00', '15:00', '16:00',
             '17:00', '18:00', '19:00', '20:00', '21:00', '22:00', '23:00'],
@@ -143,7 +143,7 @@ def test_main(call_result, capsys, caplog):
         ):
             main(call)
     captured = capsys.readouterr().out
-    assert result == captured
+    assert result in captured
     try:
         warn = call_result["warn"]
         assert warn in caplog.text


### PR DESCRIPTION
To avoid the Too Large Request error from the CDS, we have to (by default) split up the hourly land and ensemble requests up by months.

This will allow users to download ERA5-land data with era5cli. Without these changes it would be easier to use the cdsapi in python instead.

Usage examples:
```sh
era5cli hourly --land --variables soil_temperature_level_1 --startyear 2008 --area 65 20 64 21
```

```sh
era5cli hourly --variable u_component_of_wind --startyear 2008 --ensemble --statistics
```

Fixes #133, #46

**Note for the reviewer**: these changes are only in the files `fetch.py` and `test_fetch.py`.

<hr>

Additionally, I have refactored the cli module, and split up the construction of the argument parser in separate modules. This makes the main `cli.py` file more readable, and creates a more clear overview of the control flow.

All the "common" arguments are now defined in `/args/common.py`. The period parsers & arguments (e.g. `daily` or `hourly`) in `/args/periods.py`. Same for `config` and `info`.

This creates a code structure in which the actual functionality is defined in the modules `fetch` `info` and `key_management`, while the argument parsers are constructed in `cli` and `args.*`.
