### PR TITLE
Replace deprecated distutils

### DIFF
--- a/era5cli/args/periods.py
+++ b/era5cli/args/periods.py
@@ -1,7 +1,7 @@
 import argparse
-import distutils.util
 import logging
 import textwrap
+from era5cli import utils
 
 
 def add_period_args(subparsers, common):
@@ -72,7 +72,7 @@ def add_period_args(subparsers, common):
 
     splitmonths.add_argument(
         "--splitmonths",
-        type=lambda x: bool(distutils.util.strtobool(x)),  # type=bool doesn't work.
+        type=lambda x: bool(utils.strtobool(x)),  # type=bool doesn't work.
         default=None,  # To be set to True in the future
         help=textwrap.dedent(
             """

--- a/era5cli/utils.py
+++ b/era5cli/utils.py
@@ -189,16 +189,19 @@ def strtobool(value: str) -> bool:
     """Convert a string to a boolean. Required to have a true/false arg in argparse.
 
     For example: `--flag True` or `--flag False`.
+
+    Functions the same as:
+    https://github.com/pypa/distutils/blob/4435cec31b8eb5712aa8bf993bea3f07051c24d8/distutils/util.py#L340-L353
+    However, distutils will be deprecated in future Python versions.
     """
-    trues = ["true", "yes", "y", "1"]
-    falses = ["false", "no", "n", "0"]
+    trues = ["true", "t", "yes", "y", "1"]
+    falses = ["false", "f", "no", "n", "0"]
 
     if value.lower() in trues:
         return True
-    elif value.lower() in falses:
+    if value.lower() in falses:
         return False
-    else:
-        raise ValueError(
-            "Could not convert string to boolean. Valid inputs are:"
-            f"{trues} and {falses}."
-        )
+    raise ValueError(
+        "Could not convert string to boolean. Valid inputs are:"
+        f"{trues} and {falses} (case insensitive)."
+    )

--- a/era5cli/utils.py
+++ b/era5cli/utils.py
@@ -183,3 +183,22 @@ def _append_netcdf_history(ncfile: str, appendtxt: str):
     except AttributeError:
         ncfile.history = appendtxt
     ncfile.close()
+
+
+def strtobool(value: str) -> bool:
+    """Convert a string to a boolean. Required to have a true/false arg in argparse.
+
+    For example: `--flag True` or `--flag False`.
+    """
+    trues = ["true", "yes", "y", "1"]
+    falses = ["false", "no", "n", "0"]
+
+    if value.lower() in trues:
+        return True
+    elif value.lower() in falses:
+        return False
+    else:
+        raise ValueError(
+            "Could not convert string to boolean. Valid inputs are:"
+            f"{trues} and {falses}."
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -173,15 +173,14 @@ def testappend_history(tmp_path):
         ("No", False),
         ("n", False),
         ("0", False),
-    ]
+    ],
 )
 def test_strtobool(value, expected):
     """Test correct inputs."""
     assert era5cli.utils.strtobool(value) == expected
 
-@pytest.mark.parametrize(
-    "value", ["tr", "01", "maybe", "Fals"]
-)
+
+@pytest.mark.parametrize("value", ["tr", "01", "maybe", "Fals"])
 def test_strtobool_incorrect(value):
     """Test incorrect inputs."""
     with pytest.raises(ValueError, match="Could not convert string to boolean"):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -158,3 +158,31 @@ def testappend_history(tmp_path):
     new_history = ncfile.history
     appendtxt = f"Downloaded using {era5cli.__name__} {era5cliversion}."
     new_history = appendtxt
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("True", True),
+        ("true", True),
+        ("Yes", True),
+        ("y", True),
+        ("1", True),
+        ("False", False),
+        ("false", False),
+        ("No", False),
+        ("n", False),
+        ("0", False),
+    ]
+)
+def test_strtobool(value, expected):
+    """Test correct inputs."""
+    assert era5cli.utils.strtobool(value) == expected
+
+@pytest.mark.parametrize(
+    "value", ["tr", "01", "maybe", "Fals"]
+)
+def test_strtobool_incorrect(value):
+    """Test incorrect inputs."""
+    with pytest.raises(ValueError, match="Could not convert string to boolean"):
+        era5cli.utils.strtobool(value)


### PR DESCRIPTION
In #139 I made use of distutils for the `strtobool` function. However, it turns out that distutils will be deprecated. As everything was still fresh I decided to tackle this now, instead of leaving it for (possibly someone else) later.