### PR TITLE
Make prelimbe raise deprecation warning

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Change CDS keys from `.cdsapirc` file to `.config/eracli.txt` file. This will avoid conflict with e.g. ADS.
  - If a user makes a request without `--splitmonths` they are warned that the behavior will change in the future, and that they have to choose between `--splitmonths False` and `--splitmonths True`.
  - When a request would encounter a Request Too Large error in the CDS API, they are warned, and given a suggestion to use `--splitmonths`.
+ - The earliest valid start year of requests has been updated to 1950.
+ - Usage of `--prelimbe` now raises a deprecation warning. It will be deprecated in a future release, as all the back extension years are now included in the main products.
+
+**Dev changes:**
+
  - `cli.py` has been refactored to make the structure more clear. Seperate argument builders are now in their own modules.
  - The documentation has been overhauled, and now uses Markdown files & MkDocs.
 

--- a/era5cli/fetch.py
+++ b/era5cli/fetch.py
@@ -173,6 +173,14 @@ class Fetch:
                 "\neach other. Please pick one of the two."
             )
 
+        if self.prelimbe:
+            logging.warning(
+                "\n  The years of the ERA5 preliminary back extension (1950 - 1978) are"
+                "\n  now included in the main ERA5 products. The `--prelimbe` argument"
+                "\n  will be deprecated in a future release."
+                "\n  Please update your workflow accordingly."
+            )
+
         vars = list(self.variables)  # Use list() to avoid copying by reference
         if "geopotential" in vars and pressurelevels == ["surface"]:
             vars.remove("geopotential")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -100,6 +100,7 @@ call_result = [
             'reanalysis-monthly-means-of-daily-means'}
             era5_temperature_1960_monthly.nc"""
         ),
+        "warn": "The years of the ERA5 preliminary back extension",
     },
     {
         # era5-Land is combined with monthly means


### PR DESCRIPTION
Using `--prelimbe` will now raise the following warning:

```
WARNING:root:
  The years of the ERA5 preliminary back extension (1950 - 1978) are
  now included in the main ERA5 products. The `--prelimbe` argument
  will be deprecated in a future release.
  Please update your workflow accordingly.
```

The changelog has also been updated.

See #124 