### PR TITLE
Implement dashed varname option

### DIFF
--- a/era5cli/args/common.py
+++ b/era5cli/args/common.py
@@ -259,6 +259,24 @@ def add_common_args(argument_parser: ArgumentParser) -> None:
         ),
     )
 
+    argument_parser.add_argument(
+        "--dashed_varname",
+        action="store_true",
+        default=False,
+        help=textwrap.dedent(
+            """
+            Whether to use dashed variable names in the output
+            files, or the (default )normal names.
+            Dashed names can allow for easier extraction
+            of the different facets from the filename.
+            For example:
+              'era5_temperature-of-snow-layer_1999_hourly.nc'
+            instead:
+              'era5_temperature_of_snow_layer_1999_hourly.nc'
+            """
+        ),
+    )
+
 
 def construct_year_list(args):
     """Make a continous list of years from the startyear and endyear arguments."""

--- a/era5cli/args/common.py
+++ b/era5cli/args/common.py
@@ -260,7 +260,7 @@ def add_common_args(argument_parser: ArgumentParser) -> None:
     )
 
     argument_parser.add_argument(
-        "--dashed_varname",
+        "--dashed-varname",
         action="store_true",
         default=False,
         help=textwrap.dedent(

--- a/era5cli/cli.py
+++ b/era5cli/cli.py
@@ -70,6 +70,7 @@ def _execute(input_args: argparse.Namespace) -> True:
         prelimbe=input_args.prelimbe,
         land=input_args.land,
         overwrite=input_args.overwrite,
+        dashed_vars=input_args.dashed_varname,
     )
     era5.fetch(dryrun=input_args.dryrun)
     return True

--- a/era5cli/fetch.py
+++ b/era5cli/fetch.py
@@ -92,6 +92,10 @@ class Fetch:
             era5cli overwrite existing files. By default,
             you will be prompted if a file already exists, with
             the question if you want to overwrite it or not.
+        dashed_vars: bool
+            Whether to use dashed variable names in the output
+            files, or the normal names ('temperature-of-snow-layer'
+            instead of 'temperature_of_snow_layer').
     """
 
     def __init__(
@@ -115,6 +119,7 @@ class Fetch:
         prelimbe=False,
         land=False,
         overwrite=False,
+        dashed_vars=False,
     ):
         """Initialization of Fetch class."""
         self._get_login()  # Get login info from config file.
@@ -175,6 +180,9 @@ class Fetch:
         dataset."""
         self.overwrite = overwrite
         """bool: Whether to overwrite existing files."""
+        self.dashed_vars = dashed_vars
+        """bool: Whether to use dashed variable names in the output
+        files, or the normal names."""
 
         if self.merge and self.splitmonths:
             raise ValueError(
@@ -262,7 +270,10 @@ class Fetch:
 
         yearblock = f"{start}-{end}" if start != end else f"{start}"
 
-        fname = f"{prefix}_{var}_{yearblock}"
+        varname = var.replace("_", "-") if self.dashed_vars else var
+
+        fname = f"{prefix}_{varname}_{yearblock}"
+
         if month is not None:
             fname += f"-{month}"
         fname += f"_{self.period}"


### PR DESCRIPTION
Based on #53, I've added the option to have the output variable name underscores replaced with dashes (`--dashed-varname`).

For example 
`era5_temperature-of-snow-layer_1999_hourly.nc` instead of 
`era5_temperature_of_snow_layer_1999_hourly.nc`.

I am not sure if we should add this (now), because there are more and more optional arguments, but it is quite useful, as @bouweandela outlined in the issue.

I would not be against making this the default in the future.