### PR TITLE
Release 1.4.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,13 @@
+[bumpversion]
+current_version = 1.3.2
+
+[comment]
+comment = The contents of this file cannot be merged with that of pyproject.toml until https://github.com/c4urself/bump2version/issues/42 is resolved
+
+[bumpversion:file:era5cli/__version__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:CITATION.cff]
+search = version: "{current_version}"
+replace = version: "{new_version}"

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.2
+current_version = 1.4.0
 
 [comment]
 comment = The contents of this file cannot be merged with that of pyproject.toml until https://github.com/c4urself/bump2version/issues/42 is resolved

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -97,4 +97,4 @@ license: Apache-2.0
 message: "If you use this software, please cite it using these metadata."
 repository-code: "https://github.com/ewatercycle/era5cli"
 title: era5cli
-version: "1.3.2"
+version: "1.4.0"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -97,4 +97,4 @@ license: Apache-2.0
 message: "If you use this software, please cite it using these metadata."
 repository-code: "https://github.com/ewatercycle/era5cli"
 title: era5cli
-version: 1.3.2
+version: "1.3.2"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,27 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## 1.4.0 - 2021-12-13
 **Added:**
 
- - Add validator for `era5cli.txt` keys. This should provide better feedback to users and reduce user error.
- - Added --splitmonths argument for `era5cli hourly`. This allows users to avoid a Request Too Large error.
- - Added --dashed-varname argument, to produce names where the variable name is separated using hyphens. For example: `soil-type` vs. `soil_type`. For the ongoing discussion, see [#53](https://github.com/eWaterCycle/era5cli/issues/53).
+ - Add validator for `era5cli.txt` keys. This should provide better feedback to users and reduce user error ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
+ - Added --splitmonths argument for `era5cli hourly`. This allows users to avoid a Request Too Large error ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
+ - Added --dashed-varname argument, to produce file names where the variable name is separated using dashes. For example: `soil-type` vs. `soil_type`. For the ongoing discussion, see [#53](https://github.com/eWaterCycle/era5cli/issues/53).
 
 **Changed:**
 
- - Change CDS keys from `.cdsapirc` file to `.config/eracli.txt` file. This will avoid conflict with e.g. ADS.
- - If a user makes a request without `--splitmonths` they are warned that the behavior will change in the future, and that they have to choose between `--splitmonths False` and `--splitmonths True`.
- - When a request would encounter a Request Too Large error in the CDS API, they are warned, and given a suggestion to use `--splitmonths`.
- - When a file already exists and would be overwritten, the user is prompted for confirmation. This should prevent accidental overwriting of files. This check can be skipped with the `--overwrite` flag.
- - The earliest valid start year of requests has been updated to 1950.
- - Usage of `--prelimbe` now raises a deprecation warning. It will be deprecated in a future release, as all the back extension years are now included in the main products.
- - The documentation has been fully overhauled, and now uses Markdown files & MkDocs.
+ - Change CDS keys from `.cdsapirc` file to `.config/eracli.txt` file. This will avoid conflict with e.g. ADS ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
+ - If a user makes a request without `--splitmonths` they are warned that the behavior will change in the future, and that they have to choose between `--splitmonths False` and `--splitmonths True` ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
+ - When a request would encounter a Request Too Large error in the CDS API, they are warned, and given a suggestion to use `--splitmonths` ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
+ - When a file already exists and would be overwritten, the user is prompted for confirmation. This should prevent accidental overwriting of files. This check can be skipped with the `--overwrite` flag ([#143](https://github.com/eWaterCycle/era5cli/pull/143)).
+ - The earliest valid start year of requests has been updated to 1950 ([#146](https://github.com/eWaterCycle/era5cli/pull/146)).
+ - Usage of `--prelimbe` now raises a deprecation warning. It will be deprecated in a future release, as all the back extension years are now included in the main products ([#147](https://github.com/eWaterCycle/era5cli/pull/147)).
+ - The documentation has been fully overhauled, and now uses Markdown files & MkDocs ([#142](https://github.com/eWaterCycle/era5cli/pull/142), [#144](https://github.com/eWaterCycle/era5cli/pull/144)).
 
 **Dev changes:**
 
- - `cli.py` has been refactored to make the structure more clear. Seperate argument builders are now in their own modules.
+ - `cli.py` has been refactored to make the structure more clear. Seperate argument builders are now in their own modules ([#139](https://github.com/eWaterCycle/era5cli/pull/139)).
 
-## 1.3.2 - 2021-12-13
+## 1.3.2 - 2022-12-13
 **Changed:**
 
  - Elaborate the range of years that can be queried [#123](https://github.com/eWaterCycle/era5cli/pull/123)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,18 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 1.4.0 - 2023-04-18
+## 1.4.0 - 2023-04-21
 **Added:**
 
- - Add validator for `era5cli.txt` keys. This should provide better feedback to users and reduce user error ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
- - Added --splitmonths argument for `era5cli hourly`. This allows users to avoid a Request Too Large error ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
- - Added --dashed-varname argument, to produce file names where the variable name is separated using dashes. For example: `soil-type` vs. `soil_type`. For the ongoing discussion, see [#53](https://github.com/eWaterCycle/era5cli/issues/53).
+ - Add validator for user's CDS keys. This should provide better feedback to users and reduce user error ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
+ - Added `--splitmonths` argument for `era5cli hourly`. This allows users to avoid a Request Too Large error ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
+ - When a request would encounter a Request Too Large error in the CDS API, they are warned, and given a suggestion to use the new `--splitmonths` argument ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
+ - Added -`-dashed-varname` argument, to produce file names where the variable name is separated using dashes. For example: `soil-type` vs. `soil_type`. For the ongoing discussion, see [#53](https://github.com/eWaterCycle/era5cli/issues/53).
 
 **Changed:**
 
- - Change CDS keys from `.cdsapirc` file to `.config/eracli.txt` file. This will avoid conflict with e.g. ADS ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
- - If a user makes a request without `--splitmonths` they are warned that the behavior will change in the future, and that they have to choose between `--splitmonths False` and `--splitmonths True` ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
+ - Change CDS keys from cdsapi default `.cdsapirc` file to `.config/era5cli/keys.txt` file ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
+   - This will avoid conflict with e.g. ADS keys
+   - The user can configure the keys using `era5cli config`, no need to create a file in the right location.
  - When a request would encounter a Request Too Large error in the CDS API, they are warned, and given a suggestion to use `--splitmonths` ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
+ - If a user makes a request without `--splitmonths` they are warned that the behavior will change in the future, and that they have to choose between `--splitmonths False` and `--splitmonths True` 
  - When a file already exists and would be overwritten, the user is prompted for confirmation. This should prevent accidental overwriting of files. This check can be skipped with the `--overwrite` flag ([#143](https://github.com/eWaterCycle/era5cli/pull/143)).
  - The earliest valid start year of requests has been updated to 1950 ([#146](https://github.com/eWaterCycle/era5cli/pull/146)).
  - Usage of `--prelimbe` now raises a deprecation warning. It will be deprecated in a future release, as all the back extension years are now included in the main products ([#147](https://github.com/eWaterCycle/era5cli/pull/147)).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 1.4.0 - 2021-12-13
+## 1.4.0 - 2023-04-18
 **Added:**
 
  - Add validator for `era5cli.txt` keys. This should provide better feedback to users and reduce user error ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Changed:**
 
- - Change CDS keys from cdsapi default `.cdsapirc` file to `.config/era5cli/keys.txt` file ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
+ - Change CDS keys from cdsapi default `.cdsapirc` file to `.config/era5cli/cds_key.txt` file ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
    - This will avoid conflict with e.g. ADS keys
    - The user can configure the keys using `era5cli config`, no need to create a file in the right location.
  - When a request would encounter a Request Too Large error in the CDS API, they are warned, and given a suggestion to use `--splitmonths` ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -48,7 +48,7 @@ era5cli config --uid ID_NUMBER --key "KEY"
 
 *Where ID_NUMBER is your user ID (e.g. 123456) and "KEY" is your API key, inside double quotes (e.g. "4s215sgs-2dfa-6h34-62h2-1615ad163414").*
 
-After running this command your ID and key are validated and stored inside your home folder, under `.config/era5cli/keys.txt`.
+After running this command your ID and key are validated and stored inside your home folder, under `.config/era5cli/cds_key.txt`.
 
 !!! note
     If you already have a `.cdsapirc` file for the CDS api (or older version of era5cli), you will be asked if you want to copy these keys upon making an `era5cli` request.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -48,7 +48,10 @@ era5cli config --uid ID_NUMBER --key "KEY"
 
 *Where ID_NUMBER is your user ID (e.g. 123456) and "KEY" is your API key, inside double quotes (e.g. "4s215sgs-2dfa-6h34-62h2-1615ad163414").*
 
-After running this command your ID and key are validated and stored inside your home folder, under `.config/era5cli.txt.`
+After running this command your ID and key are validated and stored inside your home folder, under `.config/era5cli/keys.txt`.
+
+!!! note
+    If you already have a `.cdsapirc` file for the CDS api (or older version of era5cli), you will be asked if you want to copy these keys upon making an `era5cli` request.
 
 ## Your first request
 

--- a/era5cli/__version__.py
+++ b/era5cli/__version__.py
@@ -26,4 +26,4 @@ __author__ = (
     "Bart Schilperoort",
 )
 __email__ = "ewatercycle@esciencecenter.nl"
-__version__ = "1.3.2"
+__version__ = "1.4.0"

--- a/era5cli/key_management.py
+++ b/era5cli/key_management.py
@@ -5,7 +5,7 @@ import cdsapi
 from requests.exceptions import ConnectionError  # pylint: disable=redefined-builtin
 
 
-ERA5CLI_CONFIG_PATH = Path.home() / ".config" / "era5cli" / "keys.txt"
+ERA5CLI_CONFIG_PATH = Path.home() / ".config" / "era5cli" / "cds_key.txt"
 CDSAPI_CONFIG_PATH = Path.home() / ".cdsapirc"
 DEFAULT_CDS_URL = "https://cds.climate.copernicus.eu/api/v2"
 
@@ -141,7 +141,7 @@ def valid_cdsapi_config() -> bool:
                     "these for era5cli? [Y/n]"
                 )
                 if userinput in ["Y", "y", "Yes", "yes"]:
-                    write_era5cli_config(
+                    set_config(
                         url, uid=fullkey.split(":")[0], key=fullkey.split(":")[1]
                     )
                     return True

--- a/era5cli/key_management.py
+++ b/era5cli/key_management.py
@@ -5,7 +5,7 @@ import cdsapi
 from requests.exceptions import ConnectionError  # pylint: disable=redefined-builtin
 
 
-ERA5CLI_CONFIG_PATH = Path.home() / ".config" / "era5cli.txt"
+ERA5CLI_CONFIG_PATH = Path.home() / ".config" / "era5cli" / "keys.txt"
 CDSAPI_CONFIG_PATH = Path.home() / ".cdsapirc"
 DEFAULT_CDS_URL = "https://cds.climate.copernicus.eu/api/v2"
 

--- a/era5cli/utils.py
+++ b/era5cli/utils.py
@@ -212,9 +212,10 @@ def assert_outputfiles_not_exist(outputfiles: List[str]) -> None:
     """Check if files already exist, and prompt the user if they do."""
     if any(Path(file).exists() for file in outputfiles):
         answer = input(
-            "\n  Some filenames already exists in this folder."
+            "\n  Some file(s) that will be downloaded already exist in this folder."
             "\n  Do you want to overwrite them? (Y/N)"
             "\n  Tip: to skip this flag, use `--overwrite`."
+            "\n"
         )
         if answer.lower() in ["n", "no", "nope"]:
             raise FileExistsError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ era5cli="era5cli.cli:main"
 [project.optional-dependencies]
 dev = [
   "hatch",
+  "bump2version",
   "flake8",
   "flake8-pyproject",
   "black",


### PR DESCRIPTION
Turns out bump2version wasn't setup. Now it is.

Additionally, I moved the keys to `~/.config/era5cli/keys.txt`, as this is the standard way (instead of `~/.config/era5cli.txt`).