### PR TITLE
Add conda-forge instructions to dev docs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - When a request would encounter a Request Too Large error in the CDS API, they are warned, and given a suggestion to use `--splitmonths` ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
  - If a user makes a request without `--splitmonths` they are warned that the behavior will change in the future, and that they have to choose between `--splitmonths False` and `--splitmonths True`
  - When a file already exists and would be overwritten, the user is prompted for confirmation. This should prevent accidental overwriting of files. This check can be skipped with the `--overwrite` flag ([#143](https://github.com/eWaterCycle/era5cli/pull/143)).
- - The earliest valid start year of requests has been updated to 1950 ([#146](https://github.com/eWaterCycle/era5cli/pull/146)).
+ - The earliest valid start year of ERA5 requests has been updated to 1940 (for ERA5-land it is still 1950) ([#146](https://github.com/eWaterCycle/era5cli/pull/146)).
  - Usage of `--prelimbe` now raises a deprecation warning. It will be deprecated in a future release, as all the back extension years are now included in the main products ([#147](https://github.com/eWaterCycle/era5cli/pull/147)).
  - The documentation has been fully overhauled, and now uses Markdown files & MkDocs ([#142](https://github.com/eWaterCycle/era5cli/pull/142), [#144](https://github.com/eWaterCycle/era5cli/pull/144)).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Added:**
 
  - Add validator for user's CDS keys. This should provide better feedback to users and reduce user error ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
- - Added `--splitmonths` argument for `era5cli hourly`. This allows users to avoid a Request Too Large error ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
- - When a request would encounter a Request Too Large error in the CDS API, they are warned, and given a suggestion to use the new `--splitmonths` argument ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
+ - Added `--splitmonths` argument for `era5cli hourly`. This allows users to avoid a Request Too Large error ([#139](https://github.com/eWaterCycle/era5cli/pull/139)).
+ - When a request would encounter a Request Too Large error in the CDS API, they are warned, and given a suggestion to use the new `--splitmonths` argument ([#139](https://github.com/eWaterCycle/era5cli/pull/139)).
  - Added -`-dashed-varname` argument, to produce file names where the variable name is separated using dashes. For example: `soil-type` vs. `soil_type`. For the ongoing discussion, see [#53](https://github.com/eWaterCycle/era5cli/issues/53).
 
 **Changed:**
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Change CDS keys from cdsapi default `.cdsapirc` file to `.config/era5cli/cds_key.txt` file ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
    - This will avoid conflict with e.g. ADS keys
    - The user can configure the keys using `era5cli config`, no need to create a file in the right location.
- - When a request would encounter a Request Too Large error in the CDS API, they are warned, and given a suggestion to use `--splitmonths` ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
+ - When a request would encounter a Request Too Large error in the CDS API, they are warned, and given a suggestion to use `--splitmonths` ([#139](https://github.com/eWaterCycle/era5cli/pull/139)).
  - If a user makes a request without `--splitmonths` they are warned that the behavior will change in the future, and that they have to choose between `--splitmonths False` and `--splitmonths True`
  - When a file already exists and would be overwritten, the user is prompted for confirmation. This should prevent accidental overwriting of files. This check can be skipped with the `--overwrite` flag ([#143](https://github.com/eWaterCycle/era5cli/pull/143)).
  - The earliest valid start year of ERA5 requests has been updated to 1940 (for ERA5-land it is still 1950) ([#146](https://github.com/eWaterCycle/era5cli/pull/146)).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+**Added:**
+
+- The developer documentation now contains instructions on how to maintain the conda-forge feedstock for era5cli.
 
 ## 1.4.0 - 2023-04-21
 **Added:**
@@ -21,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - This will avoid conflict with e.g. ADS keys
    - The user can configure the keys using `era5cli config`, no need to create a file in the right location.
  - When a request would encounter a Request Too Large error in the CDS API, they are warned, and given a suggestion to use `--splitmonths` ([#138](https://github.com/eWaterCycle/era5cli/pull/138)).
- - If a user makes a request without `--splitmonths` they are warned that the behavior will change in the future, and that they have to choose between `--splitmonths False` and `--splitmonths True` 
+ - If a user makes a request without `--splitmonths` they are warned that the behavior will change in the future, and that they have to choose between `--splitmonths False` and `--splitmonths True`
  - When a file already exists and would be overwritten, the user is prompted for confirmation. This should prevent accidental overwriting of files. This check can be skipped with the `--overwrite` flag ([#143](https://github.com/eWaterCycle/era5cli/pull/143)).
  - The earliest valid start year of requests has been updated to 1950 ([#146](https://github.com/eWaterCycle/era5cli/pull/146)).
  - Usage of `--prelimbe` now raises a deprecation warning. It will be deprecated in a future release, as all the back extension years are now included in the main products ([#147](https://github.com/eWaterCycle/era5cli/pull/147)).

--- a/docs/general_development.md
+++ b/docs/general_development.md
@@ -150,9 +150,9 @@ After making the release, you should check that:
     If any contributors have been added, or the description of the software has changed, this can be edited (by eScience Center employees) via the [RSD admin interface](https://www.research-software.nl/admin/).
     More information about this process (e.g. how to add a new contributor or new affiliation) can be found in the [RSD documentation](https://github.com/research-software-directory/research-software-directory/blob/master/docs/entering-data.md) or in [this blogpost](https://blog.esciencecenter.nl/the-research-software-directory-and-how-it-promotes-software-citation-4bd2137a6b8).
 
-??? note "Maintaining the conda-forge release"
-    The new release on pypi will trigger the [conda-forge feedstock](https://github.com/conda-forge/era5cli-feedstock) to be automatically updated.
+### Maintaining the conda-forge release
+The new release on pypi will trigger the [conda-forge feedstock](https://github.com/conda-forge/era5cli-feedstock) to be automatically updated.
 
-    If nothing changed to the build configuration, the automatic pull request should pass all tests, and can be merged by one of the maintainers.
+If nothing changed to the build configuration, the automatic pull request should pass all tests, and can be merged by one of the maintainers.
 
-    If the build changed, you can fork the feedstock repository to your own account, re-generate the `recipes/meta.yml` file (for example with [Grayskull](https://github.com/conda/grayskull)), and create a pull request to the feedstock.
+If the build changed, you can fork the feedstock repository to your own account, re-generate the `recipes/meta.yml` file (for example with [Grayskull](https://github.com/conda/grayskull)), and create a pull request to the feedstock.

--- a/docs/general_development.md
+++ b/docs/general_development.md
@@ -153,6 +153,6 @@ After making the release, you should check that:
 ??? note "Maintaining the conda-forge release"
     The new release on pypi will trigger the [conda-forge feedstock](https://github.com/conda-forge/era5cli-feedstock) to be automatically updated.
 
-    If nothing changed to the built configuration, the automatic pull request should pass all tests, and can be merged by one of the maintainers.
+    If nothing changed to the build configuration, the automatic pull request should pass all tests, and can be merged by one of the maintainers.
 
-    If the built changed, you can fork the feedstock repository to your own account, re-generate the `recipes/meta.yml` file (for example with [Grayskull](https://github.com/conda/grayskull)), and create a pull request to the feedstock.
+    If the build changed, you can fork the feedstock repository to your own account, re-generate the `recipes/meta.yml` file (for example with [Grayskull](https://github.com/conda/grayskull)), and create a pull request to the feedstock.

--- a/docs/general_development.md
+++ b/docs/general_development.md
@@ -119,14 +119,14 @@ The release title is the tag and the release date together (e.g.: v1.0.0 (2019-0
 
 ??? note "Release candidates"
     When releasing a release candidate on Github, tick the pre-release box, and amend the version tag with `-rc` and the candidate number.
-    Ensure the release candidate version is accurate in `CITATION.cff` and `era5cli/__version__.py`. 
+    Ensure the release candidate version is accurate in `CITATION.cff` and `era5cli/__version__.py`.
     If the version number in these files is not updated, Zenodo release workflows will fail.
 
     Publishing a new release in github triggers the github Action workflow that builds and publishes the package to test.PyPI or PyPI.
     Versions with "rc" (release candidate) in their version tag will only be published to test.PyPI.
-    Other version tags will trigger a PyPI release. 
+    Other version tags will trigger a PyPI release.
     Inspect `.github/workflows/publish-to-pypi.yml` for more information.
-    
+
     Confirm a release candidate on test.PyPI with:
     ```
     pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ era5cli
@@ -149,3 +149,10 @@ After making the release, you should check that:
 ??? note "Adding contributors to the Research Software Directory (RSD)"
     If any contributors have been added, or the description of the software has changed, this can be edited (by eScience Center employees) via the [RSD admin interface](https://www.research-software.nl/admin/).
     More information about this process (e.g. how to add a new contributor or new affiliation) can be found in the [RSD documentation](https://github.com/research-software-directory/research-software-directory/blob/master/docs/entering-data.md) or in [this blogpost](https://blog.esciencecenter.nl/the-research-software-directory-and-how-it-promotes-software-citation-4bd2137a6b8).
+
+??? note "Maintaining the conda-forge release"
+    The new release on pypi will trigger the [conda-forge feedstock](https://github.com/conda-forge/era5cli-feedstock) to be automatically updated.
+
+    If nothing changed to the built configuration, the automatic pull request should pass all tests, and can be merged by one of the maintainers.
+
+    If the built changed, you can fork the feedstock repository to your own account, re-generate the `recipes/meta.yml` file (for example with [Grayskull](https://github.com/conda/grayskull)), and create a pull request to the feedstock.


### PR DESCRIPTION
Conda-forge instructions are added to the dev-documentation.

A mistake in a previous release changelog note has been fixed.