### PR TITLE
Fix bug when .config does not exist. Add test.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.0
+current_version = 1.4.1
 
 [comment]
 comment = The contents of this file cannot be merged with that of pyproject.toml until https://github.com/c4urself/bump2version/issues/42 is resolved

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+- repo: local
+  hooks:
+    - id: run-formatter
+      name: run-formatter
+      entry: hatch run format
+      language: system
+      types: [python]

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -97,4 +97,4 @@ license: Apache-2.0
 message: "If you use this software, please cite it using these metadata."
 repository-code: "https://github.com/ewatercycle/era5cli"
 title: era5cli
-version: "1.4.0"
+version: "1.4.1"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 
-## 1.4.1 - 2023-06-29
+## 1.4.1 - 2023-06-30
 **Fixed:**
 
  - Fix a bug that prevented the creation of the configuration file, if the "~/.config" folder did not exist yet ([#153](https://github.com/eWaterCycle/era5cli/pull/154)).
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Changed:**
  
  - Before asking for a user input, a check is made if the code is running in an interactive terminal or not. If not (e.g. if era5cli is called through a different script and stdin is not available), the input request is skipped ([#152](https://github.com/eWaterCycle/era5cli/pull/154)).
+
+**Dev changes:**
+
+ - A pre-commit hook has been added, to facilitate pre-commit users. Documentation on the setup is added to the developer documentation ([#153](https://github.com/eWaterCycle/era5cli/pull/154)). 
 
 
 ## 1.4.0 - 2023-04-21

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,13 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+
+## 1.4.1 - 2023-06-29
+**Fixed:**
+
+ - Fix a bug that prevented the creation of the configuration file, if the "~/.config" folder did not exist yet ([#153](https://github.com/eWaterCycle/era5cli/pull/154)).
+
 **Added:**
 
-- The developer documentation now contains instructions on how to maintain the conda-forge feedstock for era5cli.
+- The developer documentation now contains instructions on how to maintain the conda-forge feedstock for era5cli ([#150](https://github.com/eWaterCycle/era5cli/pull/154)).
 
 **Changed:**
  
- - Before asking for a user input, a check is made if the code is running in an interactive terminal or not. If not (e.g. if era5cli is called through a different script and stdin is not available), the input request is skipped.
+ - Before asking for a user input, a check is made if the code is running in an interactive terminal or not. If not (e.g. if era5cli is called through a different script and stdin is not available), the input request is skipped ([#152](https://github.com/eWaterCycle/era5cli/pull/154)).
 
 
 ## 1.4.0 - 2023-04-21

--- a/docs/general_development.md
+++ b/docs/general_development.md
@@ -80,6 +80,17 @@ hatch run format
 
 This will apply the `black` and `isort` formatting, and then check the code style.
 
+??? tip "Using pre-commit"
+    For pre-commit users, a pre-commit configuration has been added. This hook will execute the `hatch run format` command. 
+
+    After installing pre-commit in your python environment (`pip install pre-commit`), you can do
+    ```
+    pre-commit install
+    ```
+    to set up the git hook scripts.
+
+    For more information, see the [pre-commit website](https://pre-commit.com/).
+
 ## Generating the documentation
 
 To view the documentation locally, simply run the following command:

--- a/era5cli/__version__.py
+++ b/era5cli/__version__.py
@@ -26,4 +26,4 @@ __author__ = (
     "Bart Schilperoort",
 )
 __email__ = "ewatercycle@esciencecenter.nl"
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/era5cli/key_management.py
+++ b/era5cli/key_management.py
@@ -160,7 +160,7 @@ def load_era5cli_config() -> Tuple[str, str]:
 
 
 def write_era5cli_config(url: str, uid: str, key: str):
-    ERA5CLI_CONFIG_PATH.parent.mkdir(exist_ok=True)
+    ERA5CLI_CONFIG_PATH.parent.mkdir(exist_ok=True, parents=True)
     with open(ERA5CLI_CONFIG_PATH, mode="w", encoding="utf-8") as f:
         f.write(f"url: {url}\n")
         f.write(f"uid: {uid}\n")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,12 +6,13 @@ from era5cli import key_management
 
 @pytest.fixture(scope="function")
 def empty_path_era5(tmp_path_factory):
-    return tmp_path_factory.mktemp(".config") / "era5cli.txt"
+    return tmp_path_factory.mktemp("usrhome") / ".config" / "era5cli" / "cds_keys.txt"
 
 
 @pytest.fixture(scope="function")
 def valid_path_era5(tmp_path_factory):
-    fn = tmp_path_factory.mktemp(".config") / "era5cli.txt"
+    fn = tmp_path_factory.mktemp(".config") / "era5cli" / "cds_keys.txt"
+    fn.parent.mkdir(parents=True)
     with open(fn, mode="w", encoding="utf-8") as f:
         f.write("url: b\nuid: 123\nkey: abc-def\n")
     return fn
@@ -31,7 +32,11 @@ def valid_path_cds(tmp_path_factory):
 
 
 class TestEra5CliConfig:
-    """Test the functionality when the /.config/era5cli.txt file exists."""
+    """Test the functionality for writing and loading the config file."""
+    def test_set_config(self, empty_path_era5):
+        with patch("era5cli.key_management.ERA5CLI_CONFIG_PATH", empty_path_era5):
+            key_management.write_era5cli_config(url="b", uid="123", key="abc-def")
+            assert key_management.load_era5cli_config() == ("b", "123:abc-def")
 
     def test_load_era5cli_config(self, valid_path_era5):
         with patch("era5cli.key_management.ERA5CLI_CONFIG_PATH", valid_path_era5):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,6 +33,7 @@ def valid_path_cds(tmp_path_factory):
 
 class TestEra5CliConfig:
     """Test the functionality for writing and loading the config file."""
+
     def test_set_config(self, empty_path_era5):
         with patch("era5cli.key_management.ERA5CLI_CONFIG_PATH", empty_path_era5):
             key_management.write_era5cli_config(url="b", uid="123", key="abc-def")


### PR DESCRIPTION
Fixes #153 . The tests have been modified to be able to catch this error.
Additionally, the version has been bumped to 1.4.1 in preparation for a new release.

As a bonus I have added a pre-commit config that will run `hatch run format`, allowing devs to use pre-commit, while it should stay in sync with the linter configuration.
